### PR TITLE
Fixed two compilation bugs involving toLower()

### DIFF
--- a/source/hibernated/metadata.d
+++ b/source/hibernated/metadata.d
@@ -467,7 +467,7 @@ string camelCaseToUnderscoreDelimited(immutable string s) {
 				lastLower = false;
 				res ~= "_";
 			}
-			res ~= toLower(ch);
+			res ~= std.ascii.toLower(ch);
 		} else if (ch >= 'a' && ch <= 'z') {
 			lastLower = true;
 			res ~= ch;

--- a/source/hibernated/query.d
+++ b/source/hibernated/query.d
@@ -1519,7 +1519,7 @@ Token[] tokenize(string s) {
 					}
 				}
 			}
-			if (i < len - 1 && toLower(s[i + 1]) == 'e') {
+			if (i < len - 1 && std.ascii.toLower(s[i + 1]) == 'e') {
 				text ~= s[i+1];
 				i++;
 				if (i < len - 1 && (s[i + 1] == '-' || s[i + 1] == '+')) {


### PR DESCRIPTION
Since the import `std.string` aliases `toLower` to `std.uni.toLower` (http://dlang.org/phobos/std_string.html#.toLower), and the import `std.ascii` also implements `toLower(Char)`, DMD was confused about which one to use, and threw a compilation error for metadata.d & query.d.

This PR disambiguates its use by explicitly specifying `std.ascii.toLower` for the two calls where a `Char` is passed in.
