### PR TITLE
Make @OneToMany check for Lazy fields as well

### DIFF
--- a/source/hibernated/metadata.d
+++ b/source/hibernated/metadata.d
@@ -794,7 +794,7 @@ string getOneToManyReferencedPropertyName(T, string m)() {
     // test T has single occurance in refererType
     import std.traits : FieldTypeTuple, Filter;
     alias refererFields = FieldTypeTuple!refererType;
-    enum bool isSameType(U) = is( T == U );
+    enum bool isSameType(U) = is( T == U ) || is ( Lazy!T == U );
     alias refererFieldsofTypeT = Filter!( isSameType, refererFields );
     // assert there is exactly one field with type T in refererFields
     // when there is more than one use explicit attributes for each field eg: OneToMany( "field name first referer" ).. OneToMany( "field name second referer" )..


### PR DESCRIPTION
This allows the other side of an @OneToMany to be lazy if desired. Otherwise, it would assert the auto deduction and fail to compile.
Even if you pass a name, it runs the entire function and doesn't return out from the function. I couldn't figure out why that was happening, but this fixes it for my uses.