### PR TITLE
fix build by allowing older ddbc

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/buggins/hibernated",
     "license": "Boost Software License (BSL 1.0)",
     "dependencies": {
-        "ddbc": "~>0.3.8"
+        "ddbc": "~>0.3.7"
     },
     "targetType": "staticLibrary",
     "targetPath": "lib",


### PR DESCRIPTION
or alternatively find a way to manually update code.dlang.org to recognise `ddbc-0.3.8`, because currently it only sees `0.3.7`. See also https://github.com/dlang/dub-registry/issues/338

Also, is it necessary to be so strict with the version and update it? `dub` will get the most recent that meets the spec, so unless the old version doesn't work then there's no need to update it in the `dub.sdl`, you're just forcing people to upgrade who might have a reason not to.

If you do merge this PR, please make a patch release so other people can use it.