### PR TITLE
Fix bug where query logic uses @OneToMany referenced entity's own ID …

### DIFF
--- a/examples/example1/source/main.d
+++ b/examples/example1/source/main.d
@@ -6,21 +6,30 @@
     // Annotations of entity classes
 
     class User {
-        long id;
+        @Id @Generated
+        long userId;
         string name;
+
+        // This annotation may be left out, as it can be inferred.
+        @ManyToOne @JoinColumn("customer_id")
         Customer customer;
+
         @ManyToMany // cannot be inferred, requires annotation
         LazyCollection!Role roles;
     }
 
     class Customer {
-        int id;
+        @Id @Generated
+        int customerId;
         string name;
         // Embedded is inferred from type of Address
         Address address;
 
         Lazy!AccountType accountType; // ManyToOne inferred
 
+        // This annotation may be left out, as it can be inferred if `User` contains a member of
+        // type `Customer`.
+        @OneToMany("customer")
         User[] users; // OneToMany inferred
 
         this() {
@@ -50,7 +59,7 @@
     int main() {
 
         // create metadata from annotations
-        EntityMetaData schema = new SchemaInfoImpl!(User, Customer, AccountType, 
+        EntityMetaData schema = new SchemaInfoImpl!(User, Customer, AccountType,
                                          Address, Role);
 
 
@@ -134,6 +143,10 @@
         assert(u11.customer.users[0] == u10);
         assert(u11.roles[0].users.length == 1);
         assert(u11.roles[0].users[0] == u10);
+
+        Customer cq1 = sess.createQuery("FROM Customer WHERE name=:Name")
+            .setParameter("Name", "Customer 10").uniqueResult!Customer();
+        assert(cq1.address.zip == "12345");
 
         // remove reference
         u11.roles = u11.roles().remove(0);

--- a/examples/example1/source/main.d
+++ b/examples/example1/source/main.d
@@ -6,30 +6,21 @@
     // Annotations of entity classes
 
     class User {
-        @Id @Generated
-        long userId;
+        long id;
         string name;
-
-        // This annotation may be left out, as it can be inferred.
-        @ManyToOne @JoinColumn("customer_id")
         Customer customer;
-
         @ManyToMany // cannot be inferred, requires annotation
         LazyCollection!Role roles;
     }
 
     class Customer {
-        @Id @Generated
-        int customerId;
+        int id;
         string name;
         // Embedded is inferred from type of Address
         Address address;
 
         Lazy!AccountType accountType; // ManyToOne inferred
 
-        // This annotation may be left out, as it can be inferred if `User` contains a member of
-        // type `Customer`.
-        @OneToMany("customer")
         User[] users; // OneToMany inferred
 
         this() {
@@ -59,7 +50,7 @@
     int main() {
 
         // create metadata from annotations
-        EntityMetaData schema = new SchemaInfoImpl!(User, Customer, AccountType,
+        EntityMetaData schema = new SchemaInfoImpl!(User, Customer, AccountType, 
                                          Address, Role);
 
 
@@ -143,10 +134,6 @@
         assert(u11.customer.users[0] == u10);
         assert(u11.roles[0].users.length == 1);
         assert(u11.roles[0].users[0] == u10);
-
-        Customer cq1 = sess.createQuery("FROM Customer WHERE name=:Name")
-            .setParameter("Name", "Customer 10").uniqueResult!Customer();
-        assert(cq1.address.zip == "12345");
 
         // remove reference
         u11.roles = u11.roles().remove(0);

--- a/hdtest/source/htestmain.d
+++ b/hdtest/source/htestmain.d
@@ -41,14 +41,14 @@ class Role {
 }
 
 class Address {
-    @Generated @Id int id;
+    @Generated @Id int addressId;
     User user;
     string street;
     string town;
     string country;
 
     override string toString() {
-        return format("{id:%s, user:%s, street:%s, town:%s, country:%s}", id, user, street, town, country);
+        return format("{id:%s, user:%s, street:%s, town:%s, country:%s}", addressId, user, street, town, country);
     }
 }
 

--- a/source/hibernated/metadata.d
+++ b/source/hibernated/metadata.d
@@ -250,7 +250,7 @@ public:
     }
 
     bool opEquals(ref const PropertyInfo s) const {
-        return this == s;
+        return this is s;
     }
 
     int opCmp(ref const PropertyInfo s) const {

--- a/source/hibernated/session.d
+++ b/source/hibernated/session.d
@@ -1034,7 +1034,8 @@ class QueryImpl : Query
                     assert(false, "Delayed loader for non-join column is not yet implemented for OneToOne and ManyToOne");
                 }
             } else if (pi.oneToMany || pi.manyToMany) {
-                string hql = "FROM " ~ pi.referencedEntity.name ~ " WHERE " ~ pi.referencedPropertyName ~ "." ~ pi.referencedEntity.keyProperty.propertyName ~ " IN (" ~ keys ~ ")";
+                // The referenced property has a column referring back to this entity.
+                string hql = "FROM " ~ pi.referencedEntity.name ~ " WHERE " ~ pi.referencedPropertyName ~ "." ~ pi.entity.keyProperty.propertyName ~ " IN (" ~ keys ~ ")";
                 trace("delayedLoadRelations: loading " ~ pi.propertyName ~ " HQL: " ~ hql);
                 QueryImpl q = cast(QueryImpl)sess.createQuery(hql);
                 assert(q !is null);


### PR DESCRIPTION
…rather than referencing entity's id.

Modify example1 to use differing ID names for Customer and User.

Closes #77.