### PR TITLE
Add Simple Single-Threaded Transaction Implementation

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/buggins/hibernated",
     "license": "BSL-1.0",
     "dependencies": {
-        "ddbc": "~>0.5.8"
+        "ddbc": "~>0.6.0"
     },
     "targetType": "staticLibrary",
     "targetPath": "lib",

--- a/hdtest/source/embeddedtest.d
+++ b/hdtest/source/embeddedtest.d
@@ -2,7 +2,7 @@ module embeddedtest;
 
 import hibernated.core;
 
-import testrunner : BeforeClass, Test, AfterClass, runTests;
+import testrunner : Test;
 import hibernatetest : HibernateTest;
 
 @Embeddable

--- a/hdtest/source/htestmain.d
+++ b/hdtest/source/htestmain.d
@@ -12,6 +12,7 @@ import testrunner : runTests;
 import hibernatetest : ConnectionParams;
 import generaltest : GeneralTest;
 import embeddedtest : EmbeddedTest;
+import transactiontest : TransactionTest;
 
 int main(string[] args) {
 
@@ -31,6 +32,10 @@ int main(string[] args) {
   EmbeddedTest test2 = new EmbeddedTest();
   test2.setConnectionParams(par);
   runTests(test2);
+
+  TransactionTest test3 = new TransactionTest();
+  test3.setConnectionParams(par);
+  runTests(test3);
 
   writeln("All scenarios worked successfully");
   return 0;

--- a/hdtest/source/transactiontest.d
+++ b/hdtest/source/transactiontest.d
@@ -1,0 +1,106 @@
+module transactiontest;
+
+import std.format;
+
+import hibernated.core;
+
+import testrunner : BeforeClass, Test;
+import hibernatetest : HibernateTest;
+
+// A test entity to apply transactions to.
+class BankTxn {
+    @Id @Generated
+    long id;
+
+    string crAcct;  // Account to credit (from).
+    string drAcct;  // Account to debit (to).
+    int amount;     // Always positive.
+
+    override
+    string toString() const {
+        return format("{crAcct: \"%s\", drAcct: \"%s\", amount: %d}", crAcct, drAcct, amount);
+    }
+}
+
+class TransactionTest : HibernateTest {
+    override
+    EntityMetaData buildSchema() {
+        return new SchemaInfoImpl!(BankTxn);
+    }
+
+    @BeforeClass
+    void enableLogger() {
+        // import std.logger;
+        // (cast() sharedLog).logLevel = LogLevel.trace;
+        // globalLogLevel = LogLevel.trace;
+    }
+
+    @Test("transaction.commit")
+    void commitTest() {
+        Session sess = sessionFactory.openSession();
+        Transaction transaction = sess.beginTransaction();
+        assert(transaction.isActive() == true);
+
+        BankTxn bankTxn = new BankTxn();
+        with (bankTxn) {
+            crAcct = "0101";
+            drAcct = "0112";
+            amount = 5;
+        }
+        sess.save(bankTxn);
+        transaction.commit();
+        sess.close();  // Close the session so we can test without a cache.
+
+        sess = sessionFactory.openSession();
+        auto q1 = sess.createQuery("FROM BankTxn WHERE amount = :Amount")
+                .setParameter("Amount", 5);
+        assert(q1.uniqueResult!BankTxn() !is null);
+        sess.close();
+    }
+
+    @Test("transaction.rollback")
+    void rollbackTest() {
+        Session sess = sessionFactory.openSession();
+        Transaction transaction = sess.beginTransaction();
+        assert(transaction.isActive() == true);
+
+        BankTxn bankTxn = new BankTxn();
+        with (bankTxn) {
+            crAcct = "0101";
+            drAcct = "0112";
+            amount = 6;
+        }
+        sess.save(bankTxn);
+        transaction.rollback();
+        sess.close();  // Close the session so we can test without a cache.
+
+        sess = sessionFactory.openSession();
+        auto q1 = sess.createQuery("FROM BankTxn WHERE amount = :Amount")
+                .setParameter("Amount", 6);
+        assert(q1.uniqueResult!BankTxn() is null);
+        sess.close();
+    }
+
+    @Test("transaction.closeSessionWithoutCommit")
+    void closeSessionWithoutCommitTest() {
+        Session sess = sessionFactory.openSession();
+        Transaction transaction = sess.beginTransaction();
+        assert(transaction.isActive() == true);
+
+        BankTxn bankTxn = new BankTxn();
+        with (bankTxn) {
+            crAcct = "0101";
+            drAcct = "0112";
+            amount = 7;
+        }
+        sess.save(bankTxn);
+        // Neither transaction.commit() or transaction.rollback() is called.
+        sess.close();  // Close the session so we can test without a cache.
+
+        sess = sessionFactory.openSession();
+        auto q1 = sess.createQuery("FROM BankTxn WHERE amount = :Amount")
+                .setParameter("Amount", 6);
+        assert(q1.uniqueResult!BankTxn() is null);
+        sess.close();
+    }
+}


### PR DESCRIPTION
This is a draft implementation of Transactions for HibernateD. It does not have any session scheduler and is single threaded. However, something is a step forward compared to nothing.

This draft assumes that the changes to DDBC which incorporate autocommit/transaction support will be released as v0.6.0.