### PR TITLE
Fix memory-leak in SessionFactoryImpl::sessionClosed.

### DIFF
--- a/hdtest/source/generaltest.d
+++ b/hdtest/source/generaltest.d
@@ -83,6 +83,15 @@ class GeneralTest : HibernateTest {
     return new SchemaInfoImpl!(User, Role, Address, Asset, MyGroup);
   }
 
+  @Test("session_close")
+  void sessionCloseTest() {
+    assert((cast(SessionFactoryImpl) sessionFactory).activeSessions.length == 0);
+    Session sess = sessionFactory.openSession();
+    assert((cast(SessionFactoryImpl) sessionFactory).activeSessions.length == 1);
+    sess.close();
+    assert((cast(SessionFactoryImpl) sessionFactory).activeSessions.length == 0);
+  }
+
   @Test("general test")
   void generalTest() {
     // create session

--- a/source/hibernated/session.d
+++ b/source/hibernated/session.d
@@ -72,14 +72,22 @@ abstract class Session
     /// returns metadata
     EntityMetaData getMetaData();
 
-	/// not supported in current implementation
+	/**
+	 * Begins a new DB transaction, causing all statements run to complete together or not at all.
+	 *
+	 * All statements will attempt to be applied when returned Transaction object's `commit()`
+	 * method is called, or discarded if the `rollback()` method is called.
+	 */
 	Transaction beginTransaction();
+
 	/// not supported in current implementation
 	void cancelQuery();
+
 	/// not supported in current implementation
 	void clear();
 
-	/// closes session
+	/// Closes the session.
+	/// All sessions that are not explicitly closed will be closed when the connection is closed.
 	Connection close();
 
     ///Does this session contain any changes which must be synchronized with the database? In other words, would any DML operations be executed if we flushed this session?

--- a/source/hibernated/session.d
+++ b/source/hibernated/session.d
@@ -786,7 +786,7 @@ class SessionFactoryImpl : SessionFactory {
     void sessionClosed(SessionImpl session) {
         foreach(i, item; activeSessions) {
             if (item == session) {
-                remove(activeSessions, i);
+                activeSessions = remove(activeSessions, i);
             }
         }
     }


### PR DESCRIPTION
The std.algorithm.remove() method does not modify in-place an array, which causes 'activeSessions' to accumulate entries and never remove them.

See https://dlang.org/library/std/algorithm/mutation/remove.html
> Note that remove does not change the length of the original range directly; instead, it returns the shortened range. If its return value is not assigned to the original range, the original range will retain its original length, though its contents will have changed:

> int[] a = [ 3, 5, 7, 8 ];
> assert(remove(a, 1) == [ 3, 7, 8 ]);
> assert(a == [ 3, 7, 8, 8 ]);