### PR TITLE
Bugfix: When working with SQL queries with string paramters, SQL escape (') characters as ('').

### DIFF
--- a/hdtest/source/embeddedtest.d
+++ b/hdtest/source/embeddedtest.d
@@ -47,7 +47,8 @@ class EmbeddedTest : HibernateTest {
         assert(c1Id > 0);
 
         Customer c2 = new Customer();
-        c2.name = "Jumpy Bunny";
+        // Single quotes (') are quoted as ('') in SQL.
+        c2.name = "Erdrick O'Henry";
         c2.shippingAddress = new Address();
         c2.shippingAddress.street = "21 Grassy Knoll";
         c2.shippingAddress.city = "Warrenton";
@@ -74,6 +75,14 @@ class EmbeddedTest : HibernateTest {
         Customer c2 = r2.uniqueResult!Customer();
         assert(c2 !is null);
         assert(c2.billingAddress.street == "101001 Robotface");
+
+        // Make sure queries on strings with (') characters work.
+        auto r3 = sess.createQuery("FROM Customer WHERE name = :Name")
+                .setParameter("Name", "Erdrick O'Henry");
+        Customer c3 = r3.uniqueResult!Customer();
+        import std.stdio;
+        writeln("c3.name = ", c3.name);
+        assert(c3.shippingAddress.city == "Warrenton");
     }
 
     @Test("embedded.read.query-order-by")
@@ -139,5 +148,4 @@ class EmbeddedTest : HibernateTest {
 
         sess.close();
     }
-
 }

--- a/hdtest/source/embeddedtest.d
+++ b/hdtest/source/embeddedtest.d
@@ -80,8 +80,7 @@ class EmbeddedTest : HibernateTest {
         auto r3 = sess.createQuery("FROM Customer WHERE name = :Name")
                 .setParameter("Name", "Erdrick O'Henry");
         Customer c3 = r3.uniqueResult!Customer();
-        import std.stdio;
-        writeln("c3.name = ", c3.name);
+        assert(c3.name == "Erdrick O'Henry");
         assert(c3.shippingAddress.city == "Warrenton");
     }
 

--- a/source/hibernated/query.d
+++ b/source/hibernated/query.d
@@ -1521,7 +1521,13 @@ Token[] tokenize(string s) {
 			// string constant
 			i++;
 			for(int j=i; j<len; j++) {
-				if (s[j] != '\'') {
+				// In SQL, (') characters are quoted as ('').
+				if (s[j] == '\'' && j+1 < len && s[j+1] == '\'') {
+					text ~= s[j];
+					j++;
+					text ~= s[j];
+				}
+				else if (s[j] != '\'') {
 					text ~= s[j];
 					i = j;
 				} else {

--- a/source/hibernated/session.d
+++ b/source/hibernated/session.d
@@ -944,10 +944,12 @@ class PropertyLoadItem {
 }
 
 string createKeySQL(Variant id) {
+    import std.string : translate;
     if (id.convertsTo!long || id.convertsTo!ulong) {
         return id.toString();
     } else {
-        return "'" ~ id.toString() ~ "'";
+        // Quote (') in strings as ('') according to the SQL standard.
+        return "'" ~ id.toString().translate(['\'': "''"]) ~ "'";
     }
 }
 


### PR DESCRIPTION
During both parameter substitution as well as HQL query tokenization, the SQL escaping of (') characters as ('') is not currently respected, and results in errors like `Unfinished string near (')`.

This fix allows one to query using string parameters that contain `'` characters without encountering errors.