### PR TITLE
HQL Query Parsing via PEG Grammar #92

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,8 @@
     "homepage": "https://github.com/buggins/hibernated",
     "license": "BSL-1.0",
     "dependencies": {
-        "ddbc": "~>0.6.0"
+        "ddbc": "~>0.6.0",
+        "pegged": "~>0.4.9"
     },
     "targetType": "staticLibrary",
     "targetPath": "lib",

--- a/source/hibernated/hql.d
+++ b/source/hibernated/hql.d
@@ -1,0 +1,181 @@
+module hibernated.hql;
+
+import pegged.grammar;
+
+mixin(grammar(`
+# Basic PEG syntax: https://bford.info/pub/lang/peg.pdf
+# Notes about extended PEG syntax: https://github.com/PhilippeSigaud/Pegged/wiki/Extended-PEG-Syntax
+# 'txt' = Literal text to match against.
+# [a-z] = A character class to match against.
+# elem? = Matches an element occurring 0 or 1 times.
+# elem* = Matches an element occurring 0 or more times.
+# elem+ = Matches an element occurring 1 or more times.
+# elem1 / elem2 = First attempts to match elem1, then elem2.
+# :elem = Drop the element and its contents from the parse tree.
+# &elem = Matches if elem is found, without including elem in the containing rule.
+# !elem = Matches if elem is NOT found, without including elem in the containing rule.
+HQL:
+    Query           <-  SelectQuery  # / DeleteQuery / InsertQuery / UpdateQuery
+    SubQuery        <-  SelectQuery
+
+    SelectQuery     <-  (SelectClause :spaces)? FromClause (:spaces WhereClause)?
+    # DeleteQuery   <- (DeleteKw FromClause WhereClause?)
+
+    SelectClause    <- :SelectKw :spaces ( SelectItems ) # ( SelectItems / MapItems / ObjectItems )
+    SelectItems      <- SelectItem (:spaces? ',' :spaces? SelectItem)*
+    SelectItem      <- Expression (:spaces Alias)?
+    Alias           <- :(AsKw spaces)? !Kw identifier
+
+    FromClause      <- :FromKw :spaces IdentifierItem (:spaces Alias)?
+
+    # See https://docs.jboss.org/hibernate/orm/3.3/reference/en/html/queryhql.html#queryhql-where
+    WhereClause     <- WhereKw :spaces Expression
+
+    # HQL expressions: https://docs.jboss.org/hibernate/orm/3.3/reference/en/html/queryhql.html#queryhql-expressions
+    # For precedence, see: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE
+    Expression      <- CallExpression
+                       / Unary1Expression
+                       / BinaryExpression
+                       / TrinaryExpression
+                       / Unary2Expression
+                       / ParenExpression
+                       / SubQueryExpression
+                       / IdentifierItem / LitItem / NamedParamItem
+    BinaryExpression <- Expression :spaces BinaryOp :spaces Expression
+    BinaryOp        <- '^' / '*' / '/' / '%'
+                       / '+' / '-'
+                       / InKw / LikeKw / ILikeKw / SimilarKw
+                       / '<' / '>' / '=' / '<=' / '>=' / '<>'
+                       / IsNotKw / IsKw
+                       / AndKw / OrKw
+    TrinaryExpression <- Expression :spaces BetweenKw :spaces Expression :spaces AndKw :spaces Expression
+
+    # A method call, e.g. 'max(age)'.
+    CallExpression  <- Func :spaces? :'(' ParameterList :')'
+    Func            <- identifier
+    ParameterList   <- Expression :spaces? (',' :spaces? Expression :spaces?)*
+    ParenExpression <- '(' :spaces? Expression :spaces? ')'
+    Unary1Expression <- ( '+' / '-' ) !NumberLit Expression
+    Unary2Expression <- ( NotKw ) :spaces Expression
+
+    SubQueryExpression <- ExistsKw :'(' SubQuery :')'
+                          / Expression :spaces ( InKw / NotInKw ) :spaces? :'(' SubQuery :')'
+
+    IdentifierItem  <- !Kw identifier ( :'.' identifier )*
+    LitItem         <- StringLit / NumberLit / BoolLit / NullLit
+    NamedParamItem  <- ':' identifier
+
+    # See https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/numeric-literal-syntax?view=sql-server-ver16
+    NumberLit       <- NumExpLit / SignedNumLit
+    SignedNumLit    <~ [-+]? ;UnsignedNumLit
+    UnsignedNumLit  <~ UnsignedInt ( '.' UnsignedInt? )?
+    NumExpLit       <~ SignedNumLit [Ee] SignedInt
+    SignedInt       <- [-+]? ;UnsignedInt
+    UnsignedInt     <- [0-9]+
+
+    # Use the syntactic predicate '!' to fail a match if it starts with "'".
+    StringLit       <- "'" ( "''" / ( ! "'" . ) )* "'"
+
+    BoolLit         <- TrueKw / FalseKw
+    NullLit         <- NullKw
+
+    Kw              <~ AndKw / AsKw / AvgKw / BetweenKw / CountKw / DeleteKw / ExistsKw / FalseKw / FromKw
+                       / InKw / ILikeKw / IsKw / LikeKw / MaxKw / MinKw / NotKw / OrKw / SelectKw / SumKw
+                       / TrueKw / WhereKw
+    AndKw           <~ [Aa][Nn][Dd]
+    AsKw            <~ [Aa][Ss]
+    AvgKw           <~ [Aa][Vv][Gg]
+    BetweenKw       <~ [Bb][Ee][Tt][Ww][Ee][Ee][Nn]
+    CountKw         <~ [Cc][Oo][Uu][Nn][Tt]
+    DeleteKw        <~ [Dd][Ee][Ll][Ee][Tt][Ee]
+    ExistsKw        <~ [Ee][Xx][Ii][Ss][Tt][Ss]
+    FalseKw         <~ [Ff][Aa][Ll][Ss][Ee]
+    FromKw          <~ [Ff][Rr][Oo][Mm]
+    ILikeKw         <~ [Ii][Ll][Ii][Kk][Ee]
+    InKw            <~ [Ii][Nn]
+    IsKw            <~ [Ii][Ss]
+    IsNotKw         <~ [Ii][Ss] :spaces [Nn][Oo][Tt]
+    LikeKw          <~ [Ll][Ii][Kk][Ee]
+    MaxKw           <~ [Mm][Aa][Xx]
+    MinKw           <~ [Mm][Ii][Nn]
+    NotKw           <~ [Nn][Oo][Tt]
+    NotInKw         <~ [Nn][Oo][Tt] :spaces [Ii][Nn]
+    NullKw          <~ [Nn][Uu][Ll][Ll]
+    OrKw            <~ [Oo][Rr]
+    SelectKw        <~ [Ss][Ee][Ll][Ee][Cc][Tt]
+    SimilarKw       <~ [Ss][Ii][Mm][Ii][Ll][Aa][Rr]
+    SumKw           <~ [Ss][Uu][Mm]
+    TrueKw          <~ [Tt][Rr][Uu][Ee]
+    WhereKw         <~ [Ww][Hh][Ee][Rr][Ee]
+`));
+
+/// A sanity check on the HQL select clause.
+unittest {
+    // Dead simple HQL select.
+    assert(HQL("FROM models.Fish").successful);
+    // Select w/ numeric literals.
+    assert(HQL("SELECT 2, +3, -4, 2., 3.14, -2.45, 3.2e-12 FROM models.Fish").successful);
+    // Select w/ string literals.
+    assert(HQL("SELECT 'ham', 'O''Henry' FROM models.Fish").successful);
+    // Select w/ column names, alias-identifiers, implicit joins.
+    assert(HQL("SELECT name, f.age, f.species.id FROM models.Fish f").successful);
+    // Select w/ Parameters
+    assert(HQL("select :name, :age FROM Ham").successful);
+    // Select w/ expressions
+    assert(HQL("select 1 + 2, 1 * (3 + 4), true and false, not true and false FROM Ham").successful);
+}
+
+/// A sanity check on the HQL where clause.
+unittest {
+    // Single values are permitted for where clauses.
+    assert(HQL("FROM fish WHERE true").successful);
+    // Binary expressions.
+    assert(HQL("FROM fish WHERE a < b AND b like '%ham' OR c = 3 and d is NULL or e IS NOT null").successful);
+    // Trinary expressions.
+    assert(HQL("from fish where a between 3 and :maxA").successful);
+    // SubQuery expressions.
+    assert(HQL("FROM fish where name in (select name from Bird) or "
+            ~ "exists ( from shark where id = fish.id )").successful);
+}
+
+/// A unittest focused on parsing of a select clause in normal form (not list, object, or map).
+/// https://docs.jboss.org/hibernate/orm/3.3/reference/en/html/queryhql.html#queryhql-select
+unittest {
+    import std.stdio;
+    ParseTree pt1 = HQL("SELECT -3.2, fish goober, max(bird) as flappy, -2.3E4 FROM models.Person AS p");
+    writeln("pt1 = ", pt1);
+    assert(pt1.successful);
+    assert(pt1.children.length == 1 && pt1.children[0].name == "HQL.Query");
+
+    ParseTree query = pt1.children[0];
+    assert(query.children.length == 1 && query.children[0].name == "HQL.SelectQuery");
+
+    ParseTree selectQuery = query.children[0];
+    assert(selectQuery.children.length == 2);
+    assert(selectQuery.children[0].name == "HQL.SelectClause");
+    assert(selectQuery.children[1].name == "HQL.FromClause");
+
+    ParseTree selectClause = selectQuery.children[0];
+    assert(selectClause.children.length == 1 && selectClause.children[0].name == "HQL.SelectItems");
+
+    ParseTree arrayItems = selectClause.children[0];
+    assert(arrayItems.children.length == 4);
+    // SelectItem have up to 2 matches: Expression and Alias
+    assert(arrayItems.children[0].name == "HQL.SelectItem");
+    assert(arrayItems.children[0].matches == ["-3.2"]);
+    assert(arrayItems.children[1].matches == ["fish", "goober"]);
+    assert(arrayItems.children[2].children[0].children[0].name == "HQL.CallExpression");
+    ParseTree callExpression = arrayItems.children[2].children[0].children[0];
+    assert(callExpression.children[0].name == "HQL.Func");
+    assert(callExpression.children[0].matches == ["max"]);
+    assert(callExpression.children[1].name == "HQL.ParameterList");
+    assert(callExpression.children[1].matches == ["bird"]);
+    assert(arrayItems.children[3].matches == ["-2.3E4"]);
+
+    ParseTree fromClause = selectQuery.children[1];
+    assert(fromClause.children.length == 2);
+    assert(fromClause.children[0].name == "HQL.IdentifierItem");
+    assert(fromClause.children[0].matches == ["models", "Person"]);
+    assert(fromClause.children[1].name == "HQL.Alias");
+    assert(fromClause.children[1].matches == ["p"]);
+}

--- a/source/hibernated/query.d
+++ b/source/hibernated/query.d
@@ -1,13 +1,13 @@
 /**
- * HibernateD - Object-Relation Mapping for D programming language, with interface similar to Hibernate. 
- * 
+ * HibernateD - Object-Relation Mapping for D programming language, with interface similar to Hibernate.
+ *
  * Hibernate documentation can be found here:
  * $(LINK http://hibernate.org/docs)$(BR)
- * 
+ *
  * Source file hibernated/core.d.
  *
  * This module contains HQL query parser and HQL to SQL transform implementation.
- * 
+ *
  * Copyright: Copyright 2013
  * License:   $(LINK www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Author:   Vadim Lopatin
@@ -56,10 +56,10 @@ enum JoinType {
 }
 
 class FromClauseItem {
-	string entityName;
+    string entityName;
     const EntityInfo entity;
-	string entityAlias;
-	string sqlAlias;
+    string entityAlias;
+    string sqlAlias;
     int startColumn;
     int selectedColumns;
     // for JOINs
@@ -138,75 +138,75 @@ class FromClause {
 }
 
 struct OrderByClauseItem {
-	FromClauseItem from;
-	PropertyInfo prop;
-	bool asc;
+    FromClauseItem from;
+    PropertyInfo prop;
+    bool asc;
 }
 
 struct SelectClauseItem {
-	FromClauseItem from;
-	PropertyInfo prop;
+    FromClauseItem from;
+    PropertyInfo prop;
 }
 
 class QueryParser {
-	string query;
-	EntityMetaData metadata;
-	Token[] tokens;
+    string query;
+    EntityMetaData metadata;
+    Token[] tokens;
     FromClause fromClause;
-	//FromClauseItem[] fromClause;
-	string[] parameterNames;
-	OrderByClauseItem[] orderByClause;
-	SelectClauseItem[] selectClause;
-	Token whereClause; // AST for WHERE expression
-	
-	
-	this(EntityMetaData metadata, string query) {
-		this.metadata = metadata;
-		this.query = query;
+    //FromClauseItem[] fromClause;
+    string[] parameterNames;
+    OrderByClauseItem[] orderByClause;
+    SelectClauseItem[] selectClause;
+    Token whereClause; // AST for WHERE expression
+
+
+    this(EntityMetaData metadata, string query) {
+        this.metadata = metadata;
+        this.query = query;
         fromClause = new FromClause();
-		//trace("tokenizing query: " ~ query);
-		tokens = tokenize(query);
+        //trace("tokenizing query: " ~ query);
+        tokens = tokenize(query);
         //trace("parsing query: " ~ query);
         parse();
         //trace("parsing done");
     }
-	
-	void parse() {
-		processParameterNames(0, cast(int)tokens.length); // replace pairs {: Ident} with single Parameter token
-		int len = cast(int)tokens.length;
-		//trace("Query tokens: " ~ to!string(len));
-		int fromPos = findKeyword(KeywordType.FROM);
-		int selectPos = findKeyword(KeywordType.SELECT);
-		int wherePos = findKeyword(KeywordType.WHERE);
-		int orderPos = findKeyword(KeywordType.ORDER);
-		enforceHelper!QuerySyntaxException(fromPos >= 0, "No FROM clause in query " ~ query);
-		enforceHelper!QuerySyntaxException(selectPos <= 0, "SELECT clause should be first - invalid query " ~ query);
-		enforceHelper!QuerySyntaxException(wherePos == -1 || wherePos > fromPos, "Invalid WHERE position in query " ~ query);
-		enforceHelper!QuerySyntaxException(orderPos == -1 || (orderPos < tokens.length - 2 && tokens[orderPos + 1].keyword == KeywordType.BY), "Invalid ORDER BY in query " ~ query);
-		enforceHelper!QuerySyntaxException(orderPos == -1 || orderPos > fromPos, "Invalid ORDER BY position in query " ~ query);
-		int fromEnd = len;
-		if (orderPos >= 0)
-			fromEnd = orderPos;
-		if (wherePos >= 0)
-			fromEnd = wherePos;
-		int whereEnd = wherePos < 0 ? -1 : (orderPos >= 0 ? orderPos : len);
-		int orderEnd = orderPos < 0 ? -1 : len;
-		parseFromClause(fromPos + 1, fromEnd);
-		if (selectPos == 0 && selectPos < fromPos - 1)
-			parseSelectClause(selectPos + 1, fromPos);
-		else
-			defaultSelectClause();
-		bool selectedEntities = validateSelectClause();
-		if (wherePos >= 0 && whereEnd > wherePos)
-			parseWhereClause(wherePos + 1, whereEnd);
-		if (orderPos >= 0 && orderEnd > orderPos)
-			parseOrderClause(orderPos + 2, orderEnd);
+
+    void parse() {
+        processParameterNames(0, cast(int)tokens.length); // replace pairs {: Ident} with single Parameter token
+        int len = cast(int)tokens.length;
+        //trace("Query tokens: " ~ to!string(len));
+        int fromPos = findKeyword(KeywordType.FROM);
+        int selectPos = findKeyword(KeywordType.SELECT);
+        int wherePos = findKeyword(KeywordType.WHERE);
+        int orderPos = findKeyword(KeywordType.ORDER);
+        enforceHelper!QuerySyntaxException(fromPos >= 0, "No FROM clause in query " ~ query);
+        enforceHelper!QuerySyntaxException(selectPos <= 0, "SELECT clause should be first - invalid query " ~ query);
+        enforceHelper!QuerySyntaxException(wherePos == -1 || wherePos > fromPos, "Invalid WHERE position in query " ~ query);
+        enforceHelper!QuerySyntaxException(orderPos == -1 || (orderPos < tokens.length - 2 && tokens[orderPos + 1].keyword == KeywordType.BY), "Invalid ORDER BY in query " ~ query);
+        enforceHelper!QuerySyntaxException(orderPos == -1 || orderPos > fromPos, "Invalid ORDER BY position in query " ~ query);
+        int fromEnd = len;
+        if (orderPos >= 0)
+            fromEnd = orderPos;
+        if (wherePos >= 0)
+            fromEnd = wherePos;
+        int whereEnd = wherePos < 0 ? -1 : (orderPos >= 0 ? orderPos : len);
+        int orderEnd = orderPos < 0 ? -1 : len;
+        parseFromClause(fromPos + 1, fromEnd);
+        if (selectPos == 0 && selectPos < fromPos - 1)
+            parseSelectClause(selectPos + 1, fromPos);
+        else
+            defaultSelectClause();
+        bool selectedEntities = validateSelectClause();
+        if (wherePos >= 0 && whereEnd > wherePos)
+            parseWhereClause(wherePos + 1, whereEnd);
+        if (orderPos >= 0 && orderEnd > orderPos)
+            parseOrderClause(orderPos + 2, orderEnd);
         if (selectedEntities) {
             processAutoFetchReferences();
             prepareSelectFields();
         }
-	}
-	
+    }
+
     private void prepareSelectFields() {
         int startColumn = 1;
         for (int i=0; i < fromClause.length; i++) {
@@ -282,39 +282,39 @@ class QueryParser {
             }
         }
     }
-    
+
     private void updateEntity(const EntityInfo entity, string name) {
-		foreach(t; tokens) {
-			if (t.type == TokenType.Ident && t.text == name) {
+        foreach(t; tokens) {
+            if (t.type == TokenType.Ident && t.text == name) {
                 t.entity = cast(EntityInfo)entity;
-				t.type = TokenType.Entity;
-			}
-		}
-	}
-	
-	private void updateAlias(const EntityInfo entity, string name) {
-		foreach(t; tokens) {
-			if (t.type == TokenType.Ident && t.text == name) {
+                t.type = TokenType.Entity;
+            }
+        }
+    }
+
+    private void updateAlias(const EntityInfo entity, string name) {
+        foreach(t; tokens) {
+            if (t.type == TokenType.Ident && t.text == name) {
                 t.entity = cast(EntityInfo)entity;
-				t.type = TokenType.Alias;
-			}
-		}
-	}
-	
-	private void splitCommaDelimitedList(int start, int end, void delegate(int, int) callback) {
-		//trace("SPLIT " ~ to!string(start) ~ " .. " ~ to!string(end));
-		int len = cast(int)tokens.length;
-		int p = start;
-		for (int i = start; i < end; i++) {
-			if (tokens[i].type == TokenType.Comma || i == end - 1) {
-				enforceHelper!QuerySyntaxException(tokens[i].type != TokenType.Comma || i != end - 1, "Invalid comma at end of list" ~ errorContext(tokens[start]));
-				int endp = i < end - 1 ? i : end;
-				enforceHelper!QuerySyntaxException(endp > p, "Invalid comma delimited list" ~ errorContext(tokens[start]));
-				callback(p, endp);
-				p = i + 1;
-			}
-		}
-	}
+                t.type = TokenType.Alias;
+            }
+        }
+    }
+
+    private void splitCommaDelimitedList(int start, int end, void delegate(int, int) callback) {
+        //trace("SPLIT " ~ to!string(start) ~ " .. " ~ to!string(end));
+        int len = cast(int)tokens.length;
+        int p = start;
+        for (int i = start; i < end; i++) {
+            if (tokens[i].type == TokenType.Comma || i == end - 1) {
+                enforceHelper!QuerySyntaxException(tokens[i].type != TokenType.Comma || i != end - 1, "Invalid comma at end of list" ~ errorContext(tokens[start]));
+                int endp = i < end - 1 ? i : end;
+                enforceHelper!QuerySyntaxException(endp > p, "Invalid comma delimited list" ~ errorContext(tokens[start]));
+                callback(p, endp);
+                p = i + 1;
+            }
+        }
+    }
 
     private int parseFieldRef(int start, int end, ref string[] path) {
         int pos = start;
@@ -336,7 +336,7 @@ class QueryParser {
         enforceHelper!QuerySyntaxException(path.length > 0, "Empty field list" ~ errorContext(tokens[pos]));
         return pos;
     }
-	
+
     private void parseFirstFromClause(int start, int end, out int pos) {
         enforceHelper!QuerySyntaxException(start < end, "Invalid FROM clause " ~ errorContext(tokens[start]));
         // minimal support:
@@ -421,291 +421,291 @@ class QueryParser {
             p++;
             appendFromClause(context, path, aliasName, joinType, fetch);
         }
-		enforceHelper!QuerySyntaxException(p == end, "Invalid FROM clause" ~ errorContext(tokens[p]));
-	}
-	
-	// in pairs {: Ident} replace type of ident with Parameter 
-	void processParameterNames(int start, int end) {
-		for (int i = start; i < end; i++) {
-			if (tokens[i].type == TokenType.Parameter) {
-				parameterNames ~= cast(string)tokens[i].text;
-			}
-		}
-	}
-	
-	FromClauseItem findFromClauseByAlias(string aliasName) {
+        enforceHelper!QuerySyntaxException(p == end, "Invalid FROM clause" ~ errorContext(tokens[p]));
+    }
+
+    // in pairs {: Ident} replace type of ident with Parameter
+    void processParameterNames(int start, int end) {
+        for (int i = start; i < end; i++) {
+            if (tokens[i].type == TokenType.Parameter) {
+                parameterNames ~= cast(string)tokens[i].text;
+            }
+        }
+    }
+
+    FromClauseItem findFromClauseByAlias(string aliasName) {
         return fromClause.findByAlias(aliasName);
-	}
-	
-	void addSelectClauseItem(string aliasName, string[] propertyNames) {
-		//trace("addSelectClauseItem alias=" ~ aliasName ~ " properties=" ~ to!string(propertyNames));
-		FromClauseItem from = aliasName == null ? fromClause.first : findFromClauseByAlias(aliasName);
-		SelectClauseItem item;
-		item.from = from;
-		item.prop = null;
-		EntityInfo ei = cast(EntityInfo)from.entity;
-		if (propertyNames.length > 0) {
-			item.prop = cast(PropertyInfo)ei.findProperty(propertyNames[0]);
-			propertyNames.popFront();
-			while (item.prop.embedded) {
-				//trace("Embedded property " ~ item.prop.propertyName ~ " of type " ~ item.prop.referencedEntityName);
+    }
+
+    void addSelectClauseItem(string aliasName, string[] propertyNames) {
+        //trace("addSelectClauseItem alias=" ~ aliasName ~ " properties=" ~ to!string(propertyNames));
+        FromClauseItem from = aliasName == null ? fromClause.first : findFromClauseByAlias(aliasName);
+        SelectClauseItem item;
+        item.from = from;
+        item.prop = null;
+        EntityInfo ei = cast(EntityInfo)from.entity;
+        if (propertyNames.length > 0) {
+            item.prop = cast(PropertyInfo)ei.findProperty(propertyNames[0]);
+            propertyNames.popFront();
+            while (item.prop.embedded) {
+                //trace("Embedded property " ~ item.prop.propertyName ~ " of type " ~ item.prop.referencedEntityName);
                 ei = cast(EntityInfo)item.prop.referencedEntity;
-			    enforceHelper!QuerySyntaxException(propertyNames.length > 0, "@Embedded field property name should be specified when selecting " ~ aliasName ~ "." ~ item.prop.propertyName);
-				item.prop = cast(PropertyInfo)ei.findProperty(propertyNames[0]);
-				propertyNames.popFront();
-			}
-		}
-		enforceHelper!QuerySyntaxException(propertyNames.length == 0, "Extra field names in SELECT clause in query " ~ query);
-		selectClause ~= item;
-		//insertInPlace(selectClause, 0, item);
-	}
-	
-	//void addOrderByClauseItem(string aliasName, string propertyName, bool asc) {
+                enforceHelper!QuerySyntaxException(propertyNames.length > 0, "@Embedded field property name should be specified when selecting " ~ aliasName ~ "." ~ item.prop.propertyName);
+                item.prop = cast(PropertyInfo)ei.findProperty(propertyNames[0]);
+                propertyNames.popFront();
+            }
+        }
+        enforceHelper!QuerySyntaxException(propertyNames.length == 0, "Extra field names in SELECT clause in query " ~ query);
+        selectClause ~= item;
+        //insertInPlace(selectClause, 0, item);
+    }
+
+    //void addOrderByClauseItem(string aliasName, string propertyName, bool asc) {
     void addOrderByClauseItem(FromClauseItem from, PropertyInfo prop, bool asc) {
-		OrderByClauseItem item;
-		item.from = from;
-		item.prop = prop;
-		item.asc = asc;
-		orderByClause ~= item;
-		//insertInPlace(orderByClause, 0, item);
-	}
-	
-	void parseOrderByClauseItem(int start, int end) {
-		Token orderClauseItem = new Token(tokens[start].pos, TokenType.Expression, tokens, start, end);
-		// Convert any `[<Alias>.]<Ident>[.<Ident>]...` token sequences into fields.
-		// E.g. consider the ORDER BY fields in HQL `FROM Cats c ORDER BY c.age DESC, c.license.id ASC`.
-		convertFields(orderClauseItem.children);
+        OrderByClauseItem item;
+        item.from = from;
+        item.prop = prop;
+        item.asc = asc;
+        orderByClause ~= item;
+        //insertInPlace(orderByClause, 0, item);
+    }
 
-		enforceHelper!QuerySyntaxException(
-				orderClauseItem.children.length >= 1 && orderClauseItem.children.length <= 2
-						&& orderClauseItem.children[0].type == TokenType.Field
-						&& (orderClauseItem.children.length == 1 || orderClauseItem.children[1].type == TokenType.Keyword),
-				"Invalid ORDER BY clause (expected {property [ASC | DESC]} or {alias.property [ASC | DESC]} )" ~ errorContext(tokens[start]));
+    void parseOrderByClauseItem(int start, int end) {
+        Token orderClauseItem = new Token(tokens[start].pos, TokenType.Expression, tokens, start, end);
+        // Convert any `[<Alias>.]<Ident>[.<Ident>]...` token sequences into fields.
+        // E.g. consider the ORDER BY fields in HQL `FROM Cats c ORDER BY c.age DESC, c.license.id ASC`.
+        convertFields(orderClauseItem.children);
 
-		trace("ORDER BY ITEM: " ~ to!string(start) ~ " .. " ~ to!string(end));
-		bool asc = true;
-		if (orderClauseItem.children[$-1].type == TokenType.Keyword && orderClauseItem.children[$-1].keyword == KeywordType.DESC) {
-			asc = false;
-		}
-		addOrderByClauseItem(orderClauseItem.children[0].from, orderClauseItem.children[0].field, asc);
-	}
+        enforceHelper!QuerySyntaxException(
+                orderClauseItem.children.length >= 1 && orderClauseItem.children.length <= 2
+                        && orderClauseItem.children[0].type == TokenType.Field
+                        && (orderClauseItem.children.length == 1 || orderClauseItem.children[1].type == TokenType.Keyword),
+                "Invalid ORDER BY clause (expected {property [ASC | DESC]} or {alias.property [ASC | DESC]} )" ~ errorContext(tokens[start]));
 
-	void parseSelectClauseItem(int start, int end) {
-		// for each comma delimited item
-		// in current version it can only be
-		// {property}  or  {alias . property}
-		//trace("SELECT ITEM: " ~ to!string(start) ~ " .. " ~ to!string(end));
-		enforceHelper!QuerySyntaxException(tokens[start].type == TokenType.Ident || tokens[start].type == TokenType.Alias, "Property name or alias expected in SELECT clause in query " ~ query ~ errorContext(tokens[start]));
-		string aliasName;
-		int p = start;
-		if (tokens[p].type == TokenType.Alias) {
+        trace("ORDER BY ITEM: " ~ to!string(start) ~ " .. " ~ to!string(end));
+        bool asc = true;
+        if (orderClauseItem.children[$-1].type == TokenType.Keyword && orderClauseItem.children[$-1].keyword == KeywordType.DESC) {
+            asc = false;
+        }
+        addOrderByClauseItem(orderClauseItem.children[0].from, orderClauseItem.children[0].field, asc);
+    }
+
+    void parseSelectClauseItem(int start, int end) {
+        // for each comma delimited item
+        // in current version it can only be
+        // {property}  or  {alias . property}
+        //trace("SELECT ITEM: " ~ to!string(start) ~ " .. " ~ to!string(end));
+        enforceHelper!QuerySyntaxException(tokens[start].type == TokenType.Ident || tokens[start].type == TokenType.Alias, "Property name or alias expected in SELECT clause in query " ~ query ~ errorContext(tokens[start]));
+        string aliasName;
+        int p = start;
+        if (tokens[p].type == TokenType.Alias) {
             //trace("select clause alias: " ~ tokens[p].text ~ " query: " ~ query);
-			aliasName = cast(string)tokens[p].text;
-			p++;
-			enforceHelper!QuerySyntaxException(p == end || tokens[p].type == TokenType.Dot, "SELECT clause item is invalid (only  [alias.]field{[.field2]}+ allowed) " ~ errorContext(tokens[start]));
-			if (p < end - 1 && tokens[p].type == TokenType.Dot)
-				p++;
-		} else {
+            aliasName = cast(string)tokens[p].text;
+            p++;
+            enforceHelper!QuerySyntaxException(p == end || tokens[p].type == TokenType.Dot, "SELECT clause item is invalid (only  [alias.]field{[.field2]}+ allowed) " ~ errorContext(tokens[start]));
+            if (p < end - 1 && tokens[p].type == TokenType.Dot)
+                p++;
+        } else {
             //trace("select clause non-alias: " ~ tokens[p].text ~ " query: " ~ query);
         }
-		string[] fieldNames;
-		while (p < end && tokens[p].type == TokenType.Ident) {
-			fieldNames ~= tokens[p].text;
-			p++;
-			if (p > end - 1 || tokens[p].type != TokenType.Dot)
-				break;
-			// skipping dot
-			p++;
-		}
-		//trace("parseSelectClauseItem pos=" ~ to!string(p) ~ " end=" ~ to!string(end));
-		enforceHelper!QuerySyntaxException(p >= end, "SELECT clause item is invalid (only  [alias.]field{[.field2]}+ allowed) " ~ errorContext(tokens[start]));
-		addSelectClauseItem(aliasName, fieldNames);
-	}
-	
-	void parseSelectClause(int start, int end) {
-		enforceHelper!QuerySyntaxException(start < end, "Invalid SELECT clause" ~ errorContext(tokens[start]));
-		splitCommaDelimitedList(start, end, &parseSelectClauseItem);
-	}
-	
-	void defaultSelectClause() {
-		addSelectClauseItem(fromClause.first.entityAlias, null);
-	}
-	
-	bool validateSelectClause() {
-		enforceHelper!QuerySyntaxException(selectClause != null && selectClause.length > 0, "Invalid SELECT clause");
-		int aliasCount = 0;
-		int fieldCount = 0;
-		foreach(a; selectClause) {
-			if (a.prop !is null)
-				fieldCount++;
-			else
-				aliasCount++;
-		}
-		enforceHelper!QuerySyntaxException((aliasCount == 1 && fieldCount == 0) || (aliasCount == 0 && fieldCount > 0), "You should either use single entity alias or one or more properties in SELECT clause. Don't mix objects with primitive fields");
+        string[] fieldNames;
+        while (p < end && tokens[p].type == TokenType.Ident) {
+            fieldNames ~= tokens[p].text;
+            p++;
+            if (p > end - 1 || tokens[p].type != TokenType.Dot)
+                break;
+            // skipping dot
+            p++;
+        }
+        //trace("parseSelectClauseItem pos=" ~ to!string(p) ~ " end=" ~ to!string(end));
+        enforceHelper!QuerySyntaxException(p >= end, "SELECT clause item is invalid (only  [alias.]field{[.field2]}+ allowed) " ~ errorContext(tokens[start]));
+        addSelectClauseItem(aliasName, fieldNames);
+    }
+
+    void parseSelectClause(int start, int end) {
+        enforceHelper!QuerySyntaxException(start < end, "Invalid SELECT clause" ~ errorContext(tokens[start]));
+        splitCommaDelimitedList(start, end, &parseSelectClauseItem);
+    }
+
+    void defaultSelectClause() {
+        addSelectClauseItem(fromClause.first.entityAlias, null);
+    }
+
+    bool validateSelectClause() {
+        enforceHelper!QuerySyntaxException(selectClause != null && selectClause.length > 0, "Invalid SELECT clause");
+        int aliasCount = 0;
+        int fieldCount = 0;
+        foreach(a; selectClause) {
+            if (a.prop !is null)
+                fieldCount++;
+            else
+                aliasCount++;
+        }
+        enforceHelper!QuerySyntaxException((aliasCount == 1 && fieldCount == 0) || (aliasCount == 0 && fieldCount > 0), "You should either use single entity alias or one or more properties in SELECT clause. Don't mix objects with primitive fields");
         return aliasCount > 0;
-	}
+    }
 
-	void parseWhereClause(int start, int end) {
-		enforceHelper!QuerySyntaxException(start < end, "Invalid WHERE clause" ~ errorContext(tokens[start]));
-		whereClause = new Token(tokens[start].pos, TokenType.Expression, tokens, start, end);
-		//trace("before convert fields:\n" ~ whereClause.dump(0));
-		convertFields(whereClause.children);
-		//trace("after convertFields before convertIsNullIsNotNull:\n" ~ whereClause.dump(0));
-		convertIsNullIsNotNull(whereClause.children);
-		//trace("after convertIsNullIsNotNull\n" ~ whereClause.dump(0));
-		convertUnaryPlusMinus(whereClause.children);
-		//trace("after convertUnaryPlusMinus\n" ~ whereClause.dump(0));
-		foldBraces(whereClause.children);
-		//trace("after foldBraces\n" ~ whereClause.dump(0));
-		foldOperators(whereClause.children);
-		//trace("after foldOperators\n" ~ whereClause.dump(0));
-		dropBraces(whereClause.children);
-		//trace("after dropBraces\n" ~ whereClause.dump(0));
-	}
+    void parseWhereClause(int start, int end) {
+        enforceHelper!QuerySyntaxException(start < end, "Invalid WHERE clause" ~ errorContext(tokens[start]));
+        whereClause = new Token(tokens[start].pos, TokenType.Expression, tokens, start, end);
+        //trace("before convert fields:\n" ~ whereClause.dump(0));
+        convertFields(whereClause.children);
+        //trace("after convertFields before convertIsNullIsNotNull:\n" ~ whereClause.dump(0));
+        convertIsNullIsNotNull(whereClause.children);
+        //trace("after convertIsNullIsNotNull\n" ~ whereClause.dump(0));
+        convertUnaryPlusMinus(whereClause.children);
+        //trace("after convertUnaryPlusMinus\n" ~ whereClause.dump(0));
+        foldBraces(whereClause.children);
+        //trace("after foldBraces\n" ~ whereClause.dump(0));
+        foldOperators(whereClause.children);
+        //trace("after foldOperators\n" ~ whereClause.dump(0));
+        dropBraces(whereClause.children);
+        //trace("after dropBraces\n" ~ whereClause.dump(0));
+    }
 
-	void foldBraces(ref Token[] items) {
-		while (true) {
-			if (items.length == 0)
-				return;
-			int lastOpen = -1;
-			int firstClose = -1;
-			for (int i=0; i<items.length; i++) {
-				if (items[i].type == TokenType.OpenBracket) {
-					lastOpen = i;
-				} if (items[i].type == TokenType.CloseBracket) {
-					firstClose = i;
-					break;
-				}
-			}
-			if (lastOpen == -1 && firstClose == -1)
-				return;
-			//trace("folding braces " ~ to!string(lastOpen) ~ " .. " ~ to!string(firstClose));
-			enforceHelper!QuerySyntaxException(lastOpen >= 0 && lastOpen < firstClose, "Unpaired braces in WHERE clause" ~ errorContext(tokens[lastOpen]));
-			Token folded = new Token(items[lastOpen].pos, TokenType.Braces, items, lastOpen + 1, firstClose);
-			//			size_t oldlen = items.length;
-			//			int removed = firstClose - lastOpen;
-			replaceInPlace(items, lastOpen, firstClose + 1, [folded]);
-			//			assert(items.length == oldlen - removed);
-			foldBraces(folded.children);
-		}
-	}
-	
-	static void dropBraces(ref Token[] items) {
-		foreach (t; items) {
-			if (t.children.length > 0)
-				dropBraces(t.children);
-		}
-		for (int i=0; i<items.length; i++) {
-			if (items[i].type != TokenType.Braces)
-				continue;
-			if (items[i].children.length == 1) {
-				Token t = items[i].children[0];
-				replaceInPlace(items, i, i + 1, [t]);
-			}
-		}
-	}
-	
-	void convertIsNullIsNotNull(ref Token[] items) {
-		for (int i = cast(int)items.length - 2; i >= 0; i--) {
-			if (items[i].type != TokenType.Operator || items[i + 1].type != TokenType.Keyword)
-				continue;
-			if (items[i].operator == OperatorType.IS && items[i + 1].keyword == KeywordType.NULL) {
-				Token folded = new Token(items[i].pos,OperatorType.IS_NULL, "IS NULL");
-				replaceInPlace(items, i, i + 2, [folded]);
-				i-=2;
-			}
-		}
-		for (int i = cast(int)items.length - 3; i >= 0; i--) {
-			if (items[i].type != TokenType.Operator || items[i + 1].type != TokenType.Operator || items[i + 2].type != TokenType.Keyword)
-				continue;
-			if (items[i].operator == OperatorType.IS && items[i + 1].operator == OperatorType.NOT && items[i + 2].keyword == KeywordType.NULL) {
-				Token folded = new Token(items[i].pos, OperatorType.IS_NOT_NULL, "IS NOT NULL");
-				replaceInPlace(items, i, i + 3, [folded]);
-				i-=3;
-			}
-		}
-	}
+    void foldBraces(ref Token[] items) {
+        while (true) {
+            if (items.length == 0)
+                return;
+            int lastOpen = -1;
+            int firstClose = -1;
+            for (int i=0; i<items.length; i++) {
+                if (items[i].type == TokenType.OpenBracket) {
+                    lastOpen = i;
+                } if (items[i].type == TokenType.CloseBracket) {
+                    firstClose = i;
+                    break;
+                }
+            }
+            if (lastOpen == -1 && firstClose == -1)
+                return;
+            //trace("folding braces " ~ to!string(lastOpen) ~ " .. " ~ to!string(firstClose));
+            enforceHelper!QuerySyntaxException(lastOpen >= 0 && lastOpen < firstClose, "Unpaired braces in WHERE clause" ~ errorContext(tokens[lastOpen]));
+            Token folded = new Token(items[lastOpen].pos, TokenType.Braces, items, lastOpen + 1, firstClose);
+            //          size_t oldlen = items.length;
+            //          int removed = firstClose - lastOpen;
+            replaceInPlace(items, lastOpen, firstClose + 1, [folded]);
+            //          assert(items.length == oldlen - removed);
+            foldBraces(folded.children);
+        }
+    }
+
+    static void dropBraces(ref Token[] items) {
+        foreach (t; items) {
+            if (t.children.length > 0)
+                dropBraces(t.children);
+        }
+        for (int i=0; i<items.length; i++) {
+            if (items[i].type != TokenType.Braces)
+                continue;
+            if (items[i].children.length == 1) {
+                Token t = items[i].children[0];
+                replaceInPlace(items, i, i + 1, [t]);
+            }
+        }
+    }
+
+    void convertIsNullIsNotNull(ref Token[] items) {
+        for (int i = cast(int)items.length - 2; i >= 0; i--) {
+            if (items[i].type != TokenType.Operator || items[i + 1].type != TokenType.Keyword)
+                continue;
+            if (items[i].operator == OperatorType.IS && items[i + 1].keyword == KeywordType.NULL) {
+                Token folded = new Token(items[i].pos,OperatorType.IS_NULL, "IS NULL");
+                replaceInPlace(items, i, i + 2, [folded]);
+                i-=2;
+            }
+        }
+        for (int i = cast(int)items.length - 3; i >= 0; i--) {
+            if (items[i].type != TokenType.Operator || items[i + 1].type != TokenType.Operator || items[i + 2].type != TokenType.Keyword)
+                continue;
+            if (items[i].operator == OperatorType.IS && items[i + 1].operator == OperatorType.NOT && items[i + 2].keyword == KeywordType.NULL) {
+                Token folded = new Token(items[i].pos, OperatorType.IS_NOT_NULL, "IS NOT NULL");
+                replaceInPlace(items, i, i + 3, [folded]);
+                i-=3;
+            }
+        }
+    }
 
     /**
      * During the parsing of an HQL query, populates Tokens with TokenType Ident or Alias with
      * contextual information such as EntityInfo, PropertyInfo, and more.
      */
-	void convertFields(ref Token[] items) {
-		while(true) {
+    void convertFields(ref Token[] items) {
+        while(true) {
             // Find the first Ident/Alias token and keep its index in `p`.
-			int p = -1;
-			for (int i=0; i<items.length; i++) {
-				if (items[i].type != TokenType.Ident && items[i].type != TokenType.Alias)
-					continue;
-				p = i;
-				break;
-			}
-			if (p == -1)
-				return;
+            int p = -1;
+            for (int i=0; i<items.length; i++) {
+                if (items[i].type != TokenType.Ident && items[i].type != TokenType.Alias)
+                    continue;
+                p = i;
+                break;
+            }
+            if (p == -1)
+                return;
 
-			// A property may be referenced in the form:
-			//   [<Alias>.] <Ident> [.<Ident>]...
-			// Extract only the Alias and Ident tokens, without Dot tokens, and store that in `idents`.
-			// Each dot represents either an @Embeddable property or a join.
-			string[] idents;
-			int lastp = p;
-			idents ~= items[p].text;
-			for (int i=p + 1; i < items.length - 1; i+=2) {
-				if (items[i].type != TokenType.Dot)
-					break;
-				enforceHelper!QuerySyntaxException(
+            // A property may be referenced in the form:
+            //   [<Alias>.] <Ident> [.<Ident>]...
+            // Extract only the Alias and Ident tokens, without Dot tokens, and store that in `idents`.
+            // Each dot represents either an @Embeddable property or a join.
+            string[] idents;
+            int lastp = p;
+            idents ~= items[p].text;
+            for (int i=p + 1; i < items.length - 1; i+=2) {
+                if (items[i].type != TokenType.Dot)
+                    break;
+                enforceHelper!QuerySyntaxException(
                         i < items.length - 1 && items[i + 1].type == TokenType.Ident,
                         "Syntax error in property - no property name after . " ~ errorContext(items[p]));
-				lastp = i + 1;
-				idents ~= items[i + 1].text;
-			}
+                lastp = i + 1;
+                idents ~= items[i + 1].text;
+            }
 
-			// Determine the entity in the FromClause being referred to and make `idents` contain only Ident tokens.
-			FromClauseItem a;
-			if (items[p].type == TokenType.Alias) {
-				a = findFromClauseByAlias(idents[0]);
-				idents.popFront();
-			} else {
-				// use first FROM clause if alias is not specified
-				a = fromClause.first;
-			}
-			string aliasName = a.entityAlias;
+            // Determine the entity in the FromClause being referred to and make `idents` contain only Ident tokens.
+            FromClauseItem a;
+            if (items[p].type == TokenType.Alias) {
+                a = findFromClauseByAlias(idents[0]);
+                idents.popFront();
+            } else {
+                // use first FROM clause if alias is not specified
+                a = fromClause.first;
+            }
+            string aliasName = a.entityAlias;
             EntityInfo ei = cast(EntityInfo)a.entity;
-			enforceHelper!QuerySyntaxException(idents.length > 0,
+            enforceHelper!QuerySyntaxException(idents.length > 0,
                     "Syntax error in property - alias w/o property name: " ~ aliasName ~ errorContext(items[p]));
 
-			// Dive through the list of identifiers, searching through embedded properties and joins.
-			PropertyInfo pi;
-			string fullName;
-			string columnPrefix;
-			fullName = aliasName;
-			while(true) {
-    			string propertyName = idents[0];
-    			idents.popFront();
-    			fullName ~= "." ~ propertyName;
+            // Dive through the list of identifiers, searching through embedded properties and joins.
+            PropertyInfo pi;
+            string fullName;
+            string columnPrefix;
+            fullName = aliasName;
+            while(true) {
+                string propertyName = idents[0];
+                idents.popFront();
+                fullName ~= "." ~ propertyName;
                 pi = cast(PropertyInfo)ei.findProperty(propertyName);
 
-				// First consume all the dot-separated identifiers for @Embedded properties.
-    			while (pi.embedded) { // loop to allow nested @Embedded
-    				enforceHelper!QuerySyntaxException(
-							idents.length > 0,
-							"Syntax error in property - @Embedded property reference should include reference to @Embeddable property "
-									~ aliasName ~ errorContext(items[p]));
-					// The `columnName` of an `@Embedded` property contains an optional prefix to add to the
-					// column names of the properties inside its entity type.
+                // First consume all the dot-separated identifiers for @Embedded properties.
+                while (pi.embedded) { // loop to allow nested @Embedded
+                    enforceHelper!QuerySyntaxException(
+                            idents.length > 0,
+                            "Syntax error in property - @Embedded property reference should include reference to @Embeddable property "
+                                    ~ aliasName ~ errorContext(items[p]));
+                    // The `columnName` of an `@Embedded` property contains an optional prefix to add to the
+                    // column names of the properties inside its entity type.
                     columnPrefix ~= pi.columnName == "" ? pi.columnName : pi.columnName ~ "_";
-    				propertyName = idents[0];
-    				idents.popFront();
+                    propertyName = idents[0];
+                    idents.popFront();
                     pi = cast(PropertyInfo)pi.referencedEntity.findProperty(propertyName);
-    				fullName = fullName ~ "." ~ propertyName;
-    			}
+                    fullName = fullName ~ "." ~ propertyName;
+                }
                 if (idents.length == 0)
                     break;
 
-				// Next consume all the dot-separated identifiers for explicit or implicit joins.
+                // Next consume all the dot-separated identifiers for explicit or implicit joins.
                 if (idents.length > 0) {
-					// There are more names after `propertyName`, whose property info is in `pi`.
-					string pname = idents[0];
+                    // There are more names after `propertyName`, whose property info is in `pi`.
+                    string pname = idents[0];
                     enforceHelper!QuerySyntaxException(pi.referencedEntity !is null, "Unexpected extra field name " ~ pname ~ " - property " ~ propertyName ~ " doesn't content subproperties " ~ errorContext(items[p]));
                     ei = cast(EntityInfo)pi.referencedEntity;
                     // Check if the referenced entity is already in a from-clause, if not, implicitly add it.
@@ -717,42 +717,42 @@ class QueryParser {
                     a = newClause;
                 }
             }
-			enforceHelper!QuerySyntaxException(idents.length == 0, "Unexpected extra field name " ~ idents[0] ~ errorContext(items[p]));
-			//trace("full name = " ~ fullName);
+            enforceHelper!QuerySyntaxException(idents.length == 0, "Unexpected extra field name " ~ idents[0] ~ errorContext(items[p]));
+            //trace("full name = " ~ fullName);
 
             // Replace a sequence of tokens in `items[p..lastp+1]` of the form:
             //   [<Alias>.] <Ident> [.<Ident>]...
             // with a single Field token, containing the EntityInfo and PropertyInfo of the referenced entity and property.
-			Token t = new Token(/+pos+/ items[p].pos, /+type+/ TokenType.Field, /+text+/ fullName);
+            Token t = new Token(/+pos+/ items[p].pos, /+type+/ TokenType.Field, /+text+/ fullName);
             t.entity = cast(EntityInfo)ei;
             t.field = cast(PropertyInfo)pi;
             t.columnPrefix = columnPrefix;
-			t.from = a;
-			replaceInPlace(items, p, lastp + 1, [t]);
-		}
-	}
-	
-	static void convertUnaryPlusMinus(ref Token[] items) {
-		foreach (t; items) {
-			if (t.children.length > 0)
-				convertUnaryPlusMinus(t.children);
-		}
-		for (int i=0; i<items.length; i++) {
-			if (items[i].type != TokenType.Operator)
-				continue;
-			OperatorType op = items[i].operator;
-			if (op == OperatorType.ADD || op == OperatorType.SUB) {
-				// convert + and - to unary form if necessary
-				if (i == 0 || !items[i - 1].isExpression()) {
-					items[i].operator = (op == OperatorType.ADD) ? OperatorType.UNARY_PLUS : OperatorType.UNARY_MINUS;
-				}
-			}
-		}
-	}
-	
-	string errorContext(Token token) {
-		return " near `" ~ query[token.pos .. $] ~ "` in query `" ~ query ~ "`";
-	}
+            t.from = a;
+            replaceInPlace(items, p, lastp + 1, [t]);
+        }
+    }
+
+    static void convertUnaryPlusMinus(ref Token[] items) {
+        foreach (t; items) {
+            if (t.children.length > 0)
+                convertUnaryPlusMinus(t.children);
+        }
+        for (int i=0; i<items.length; i++) {
+            if (items[i].type != TokenType.Operator)
+                continue;
+            OperatorType op = items[i].operator;
+            if (op == OperatorType.ADD || op == OperatorType.SUB) {
+                // convert + and - to unary form if necessary
+                if (i == 0 || !items[i - 1].isExpression()) {
+                    items[i].operator = (op == OperatorType.ADD) ? OperatorType.UNARY_PLUS : OperatorType.UNARY_MINUS;
+                }
+            }
+        }
+    }
+
+    string errorContext(Token token) {
+        return " near `" ~ query[token.pos .. $] ~ "` in query `" ~ query ~ "`";
+    }
 
     void foldCommaSeparatedList(Token braces) {
         // fold inside braces
@@ -775,49 +775,49 @@ class QueryParser {
         braces.children = list;
     }
 
-	void foldOperators(ref Token[] items) {
-		foreach (t; items) {
-			if (t.children.length > 0)
-				foldOperators(t.children);
-		}
-		while (true) {
-			//
-			int bestOpPosition = -1;
-			int bestOpPrecedency = -1;
-			OperatorType t = OperatorType.NONE;
-			for (int i=0; i<items.length; i++) {
-				if (items[i].type != TokenType.Operator)
-					continue;
-				int p = operatorPrecedency(items[i].operator);
-				if (p > bestOpPrecedency) {
-					bestOpPrecedency = p;
-					bestOpPosition = i;
-					t = items[i].operator;
-				}
-			}
-			if (bestOpPrecedency == -1)
-				return;
-			//trace("Found op " ~ items[bestOpPosition].toString() ~ " at position " ~ to!string(bestOpPosition) ~ " with priority " ~ to!string(bestOpPrecedency));
-			if (t == OperatorType.NOT || t == OperatorType.UNARY_PLUS || t == OperatorType.UNARY_MINUS) {
-				// fold unary
-				enforceHelper!QuerySyntaxException(bestOpPosition < items.length && items[bestOpPosition + 1].isExpression(), "Syntax error in WHERE condition " ~ errorContext(items[bestOpPosition]));
-				Token folded = new Token(items[bestOpPosition].pos, t, items[bestOpPosition].text, items[bestOpPosition + 1]);
-				replaceInPlace(items, bestOpPosition, bestOpPosition + 2, [folded]);
-			} else if (t == OperatorType.IS_NULL || t == OperatorType.IS_NOT_NULL) {
-				// fold unary
-				enforceHelper!QuerySyntaxException(bestOpPosition > 0 && items[bestOpPosition - 1].isExpression(), "Syntax error in WHERE condition " ~ errorContext(items[bestOpPosition]));
-				Token folded = new Token(items[bestOpPosition - 1].pos, t, items[bestOpPosition].text, items[bestOpPosition - 1]);
-				replaceInPlace(items, bestOpPosition - 1, bestOpPosition + 1, [folded]);
-			} else if (t == OperatorType.BETWEEN) {
-				// fold  X BETWEEN A AND B
-				enforceHelper!QuerySyntaxException(bestOpPosition > 0, "Syntax error in WHERE condition - no left arg for BETWEEN operator");
-				enforceHelper!QuerySyntaxException(bestOpPosition < items.length - 1, "Syntax error in WHERE condition - no min bound for BETWEEN operator " ~ errorContext(items[bestOpPosition]));
-				enforceHelper!QuerySyntaxException(bestOpPosition < items.length - 3, "Syntax error in WHERE condition - no max bound for BETWEEN operator " ~ errorContext(items[bestOpPosition]));
-				enforceHelper!QuerySyntaxException(items[bestOpPosition + 2].operator == OperatorType.AND, "Syntax error in WHERE condition - no max bound for BETWEEN operator" ~ errorContext(items[bestOpPosition]));
-				Token folded = new Token(items[bestOpPosition - 1].pos, t, items[bestOpPosition].text, items[bestOpPosition - 1]);
-				folded.children ~= items[bestOpPosition + 1];
-				folded.children ~= items[bestOpPosition + 3];
-				replaceInPlace(items, bestOpPosition - 1, bestOpPosition + 4, [folded]);
+    void foldOperators(ref Token[] items) {
+        foreach (t; items) {
+            if (t.children.length > 0)
+                foldOperators(t.children);
+        }
+        while (true) {
+            //
+            int bestOpPosition = -1;
+            int bestOpPrecedency = -1;
+            OperatorType t = OperatorType.NONE;
+            for (int i=0; i<items.length; i++) {
+                if (items[i].type != TokenType.Operator)
+                    continue;
+                int p = operatorPrecedency(items[i].operator);
+                if (p > bestOpPrecedency) {
+                    bestOpPrecedency = p;
+                    bestOpPosition = i;
+                    t = items[i].operator;
+                }
+            }
+            if (bestOpPrecedency == -1)
+                return;
+            //trace("Found op " ~ items[bestOpPosition].toString() ~ " at position " ~ to!string(bestOpPosition) ~ " with priority " ~ to!string(bestOpPrecedency));
+            if (t == OperatorType.NOT || t == OperatorType.UNARY_PLUS || t == OperatorType.UNARY_MINUS) {
+                // fold unary
+                enforceHelper!QuerySyntaxException(bestOpPosition < items.length && items[bestOpPosition + 1].isExpression(), "Syntax error in WHERE condition " ~ errorContext(items[bestOpPosition]));
+                Token folded = new Token(items[bestOpPosition].pos, t, items[bestOpPosition].text, items[bestOpPosition + 1]);
+                replaceInPlace(items, bestOpPosition, bestOpPosition + 2, [folded]);
+            } else if (t == OperatorType.IS_NULL || t == OperatorType.IS_NOT_NULL) {
+                // fold unary
+                enforceHelper!QuerySyntaxException(bestOpPosition > 0 && items[bestOpPosition - 1].isExpression(), "Syntax error in WHERE condition " ~ errorContext(items[bestOpPosition]));
+                Token folded = new Token(items[bestOpPosition - 1].pos, t, items[bestOpPosition].text, items[bestOpPosition - 1]);
+                replaceInPlace(items, bestOpPosition - 1, bestOpPosition + 1, [folded]);
+            } else if (t == OperatorType.BETWEEN) {
+                // fold  X BETWEEN A AND B
+                enforceHelper!QuerySyntaxException(bestOpPosition > 0, "Syntax error in WHERE condition - no left arg for BETWEEN operator");
+                enforceHelper!QuerySyntaxException(bestOpPosition < items.length - 1, "Syntax error in WHERE condition - no min bound for BETWEEN operator " ~ errorContext(items[bestOpPosition]));
+                enforceHelper!QuerySyntaxException(bestOpPosition < items.length - 3, "Syntax error in WHERE condition - no max bound for BETWEEN operator " ~ errorContext(items[bestOpPosition]));
+                enforceHelper!QuerySyntaxException(items[bestOpPosition + 2].operator == OperatorType.AND, "Syntax error in WHERE condition - no max bound for BETWEEN operator" ~ errorContext(items[bestOpPosition]));
+                Token folded = new Token(items[bestOpPosition - 1].pos, t, items[bestOpPosition].text, items[bestOpPosition - 1]);
+                folded.children ~= items[bestOpPosition + 1];
+                folded.children ~= items[bestOpPosition + 3];
+                replaceInPlace(items, bestOpPosition - 1, bestOpPosition + 4, [folded]);
             } else if (t == OperatorType.IN) {
                 // fold  X IN (A, B, ...)
                 enforceHelper!QuerySyntaxException(bestOpPosition > 0, "Syntax error in WHERE condition - no left arg for IN operator");
@@ -830,35 +830,35 @@ class QueryParser {
                 // fold value list
                 //trace("IN operator found: " ~ folded.dump(3));
             } else {
-				// fold binary
-				enforceHelper!QuerySyntaxException(bestOpPosition > 0, "Syntax error in WHERE condition - no left arg for binary operator " ~ errorContext(items[bestOpPosition]));
-				enforceHelper!QuerySyntaxException(bestOpPosition < items.length - 1, "Syntax error in WHERE condition - no right arg for binary operator " ~ errorContext(items[bestOpPosition]));
-				//trace("binary op " ~ items[bestOpPosition - 1].toString() ~ " " ~ items[bestOpPosition].toString() ~ " " ~ items[bestOpPosition + 1].toString());
-				enforceHelper!QuerySyntaxException(items[bestOpPosition - 1].isExpression(), "Syntax error in WHERE condition - wrong type of left arg for binary operator " ~ errorContext(items[bestOpPosition]));
-				enforceHelper!QuerySyntaxException(items[bestOpPosition + 1].isExpression(), "Syntax error in WHERE condition - wrong type of right arg for binary operator " ~ errorContext(items[bestOpPosition]));
-				Token folded = new Token(items[bestOpPosition - 1].pos, t, items[bestOpPosition].text, items[bestOpPosition - 1], items[bestOpPosition + 1]);
-				auto oldlen = items.length;
-				replaceInPlace(items, bestOpPosition - 1, bestOpPosition + 2, [folded]);
-				assert(items.length == oldlen - 2);
-			}
-		}
-	}
-	
-	void parseOrderClause(int start, int end) {
-		enforceHelper!QuerySyntaxException(start < end, "Invalid ORDER BY clause" ~ errorContext(tokens[start]));
+                // fold binary
+                enforceHelper!QuerySyntaxException(bestOpPosition > 0, "Syntax error in WHERE condition - no left arg for binary operator " ~ errorContext(items[bestOpPosition]));
+                enforceHelper!QuerySyntaxException(bestOpPosition < items.length - 1, "Syntax error in WHERE condition - no right arg for binary operator " ~ errorContext(items[bestOpPosition]));
+                //trace("binary op " ~ items[bestOpPosition - 1].toString() ~ " " ~ items[bestOpPosition].toString() ~ " " ~ items[bestOpPosition + 1].toString());
+                enforceHelper!QuerySyntaxException(items[bestOpPosition - 1].isExpression(), "Syntax error in WHERE condition - wrong type of left arg for binary operator " ~ errorContext(items[bestOpPosition]));
+                enforceHelper!QuerySyntaxException(items[bestOpPosition + 1].isExpression(), "Syntax error in WHERE condition - wrong type of right arg for binary operator " ~ errorContext(items[bestOpPosition]));
+                Token folded = new Token(items[bestOpPosition - 1].pos, t, items[bestOpPosition].text, items[bestOpPosition - 1], items[bestOpPosition + 1]);
+                auto oldlen = items.length;
+                replaceInPlace(items, bestOpPosition - 1, bestOpPosition + 2, [folded]);
+                assert(items.length == oldlen - 2);
+            }
+        }
+    }
+
+    void parseOrderClause(int start, int end) {
+        enforceHelper!QuerySyntaxException(start < end, "Invalid ORDER BY clause" ~ errorContext(tokens[start]));
         trace("tokens[start..end]=", tokens[start..end].to!string);
-		splitCommaDelimitedList(start, end, &parseOrderByClauseItem);
-	}
-	
-	/// returns position of keyword in tokens array, -1 if not found
-	int findKeyword(KeywordType k, int startFrom = 0) {
-		for (int i = startFrom; i < tokens.length; i++) {
-			if (tokens[i].type == TokenType.Keyword && tokens[i].keyword == k)
-				return i;
-		}
-		return -1;
-	}
-	
+        splitCommaDelimitedList(start, end, &parseOrderByClauseItem);
+    }
+
+    /// returns position of keyword in tokens array, -1 if not found
+    int findKeyword(KeywordType k, int startFrom = 0) {
+        for (int i = startFrom; i < tokens.length; i++) {
+            if (tokens[i].type == TokenType.Keyword && tokens[i].keyword == k)
+                return i;
+        }
+        return -1;
+    }
+
     int addSelectSQL(Dialect dialect, ParsedQuery res, string tableName, bool first,
             const EntityInfo ei, string prefix="") {
         int colCount = 0;
@@ -879,23 +879,23 @@ class QueryParser {
                 res.appendSQL(", ");
             } else
                 first = false;
-            
+
             res.appendSQL(tableName ~ "." ~ dialect.quoteIfNeeded(fieldName));
             colCount++;
         }
         return colCount;
     }
 
-	void addSelectSQL(Dialect dialect, ParsedQuery res) {
-		res.appendSQL("SELECT ");
-		bool first = true;
-		assert(selectClause.length > 0);
-		int colCount = 0;
+    void addSelectSQL(Dialect dialect, ParsedQuery res) {
+        res.appendSQL("SELECT ");
+        bool first = true;
+        assert(selectClause.length > 0);
+        int colCount = 0;
         foreach(i, s; selectClause) {
             s.from.selectIndex = cast(int)i;
         }
-		if (selectClause[0].prop is null) {
-			// object alias is specified: add all properties of object
+        if (selectClause[0].prop is null) {
+            // object alias is specified: add all properties of object
             //trace("selected entity count: " ~ to!string(selectClause.length));
             res.setEntity(selectClause[0].from.entity);
             for(int i = 0; i < fromClause.length; i++) {
@@ -903,33 +903,33 @@ class QueryParser {
                 if (!from.fetch)
                     continue;
                 string tableName = from.sqlAlias;
-    			assert(from !is null);
-    			assert(from.entity !is null);
+                assert(from !is null);
+                assert(from.entity !is null);
                 colCount += addSelectSQL(dialect, res, tableName, colCount == 0, from.entity);
             }
-		} else {
-			// individual fields specified
-			res.setEntity(null);
-			foreach(a; selectClause) {
-				string fieldName = a.prop.columnName;
-				string tableName = a.from.sqlAlias;
-				if (!first) {
-					res.appendSQL(", ");
-				} else
-					first = false;
-				res.appendSQL(tableName ~ "." ~ dialect.quoteIfNeeded(fieldName));
-				colCount++;
-			}
-		}
-		res.setColCount(colCount);
+        } else {
+            // individual fields specified
+            res.setEntity(null);
+            foreach(a; selectClause) {
+                string fieldName = a.prop.columnName;
+                string tableName = a.from.sqlAlias;
+                if (!first) {
+                    res.appendSQL(", ");
+                } else
+                    first = false;
+                res.appendSQL(tableName ~ "." ~ dialect.quoteIfNeeded(fieldName));
+                colCount++;
+            }
+        }
+        res.setColCount(colCount);
         res.setSelect(selectClause);
-	}
-	
-	void addFromSQL(Dialect dialect, ParsedQuery res) {
+    }
+
+    void addFromSQL(Dialect dialect, ParsedQuery res) {
         res.setFromClause(fromClause);
-		res.appendSpace();
-		res.appendSQL("FROM ");
-		res.appendSQL(dialect.quoteIfNeeded(fromClause.first.entity.tableName) ~ " AS " ~ fromClause.first.sqlAlias);
+        res.appendSpace();
+        res.appendSQL("FROM ");
+        res.appendSQL(dialect.quoteIfNeeded(fromClause.first.entity.tableName) ~ " AS " ~ fromClause.first.sqlAlias);
         for (int i = 1; i < fromClause.length; i++) {
             FromClauseItem join = fromClause[i];
             FromClauseItem base = join.base;
@@ -1013,27 +1013,27 @@ class QueryParser {
                 }
             }
         }
-	}
+    }
 
     // Converts a token into SQL and appends it to a WHERE section of a query.
-	void addWhereCondition(Token t, int basePrecedency, Dialect dialect, ParsedQuery res) {
-		if (t.type == TokenType.Expression) {
-			addWhereCondition(t.children[0], basePrecedency, dialect, res);
-		} else if (t.type == TokenType.Field) {
-			string tableName = t.from.sqlAlias;
-			string fieldName = t.columnPrefix ~ t.field.columnName;
-			res.appendSpace();
-			res.appendSQL(tableName ~ "." ~ dialect.quoteIfNeeded(fieldName));
-		} else if (t.type == TokenType.Number) {
-			res.appendSpace();
-			res.appendSQL(t.text);
-		} else if (t.type == TokenType.String) {
-			res.appendSpace();
-			res.appendSQL(dialect.quoteSqlString(t.text));
-		} else if (t.type == TokenType.Parameter) {
-			res.appendSpace();
-			res.appendSQL("?");
-			res.addParam(t.text);
+    void addWhereCondition(Token t, int basePrecedency, Dialect dialect, ParsedQuery res) {
+        if (t.type == TokenType.Expression) {
+            addWhereCondition(t.children[0], basePrecedency, dialect, res);
+        } else if (t.type == TokenType.Field) {
+            string tableName = t.from.sqlAlias;
+            string fieldName = t.columnPrefix ~ t.field.columnName;
+            res.appendSpace();
+            res.appendSQL(tableName ~ "." ~ dialect.quoteIfNeeded(fieldName));
+        } else if (t.type == TokenType.Number) {
+            res.appendSpace();
+            res.appendSQL(t.text);
+        } else if (t.type == TokenType.String) {
+            res.appendSpace();
+            res.appendSQL(dialect.quoteSqlString(t.text));
+        } else if (t.type == TokenType.Parameter) {
+            res.appendSpace();
+            res.appendSQL("?");
+            res.addParam(t.text);
         } else if (t.type == TokenType.CommaDelimitedList) {
             bool first = true;
             for (int i=0; i<t.children.length; i++) {
@@ -1044,61 +1044,61 @@ class QueryParser {
                 addWhereCondition(t.children[i], 0, dialect, res);
             }
         } else if (t.type == TokenType.OpExpr) {
-			int currentPrecedency = operatorPrecedency(t.operator);
-			bool needBraces = currentPrecedency < basePrecedency;
-			if (needBraces)
-				res.appendSQL("(");
-			switch(t.operator) {
-				case OperatorType.LIKE:
-				case OperatorType.EQ:
-				case OperatorType.NE:
-				case OperatorType.LT:
-				case OperatorType.GT:
-				case OperatorType.LE:
-				case OperatorType.GE:
-				case OperatorType.MUL:
-				case OperatorType.ADD:
-				case OperatorType.SUB:
-				case OperatorType.DIV:
-				case OperatorType.AND:
-				case OperatorType.OR:
-				case OperatorType.IDIV:
-				case OperatorType.MOD:
-					// binary op
-					if (!needBraces)
-						res.appendSpace();
-					addWhereCondition(t.children[0], currentPrecedency, dialect, res);
-					res.appendSpace();
-					res.appendSQL(t.text);
-					res.appendSpace();
-					addWhereCondition(t.children[1], currentPrecedency, dialect, res);
-					break;
-				case OperatorType.UNARY_PLUS:
-				case OperatorType.UNARY_MINUS:
-				case OperatorType.NOT:
-					// unary op
-					if (!needBraces)
-						res.appendSpace();
-					res.appendSQL(t.text);
-					res.appendSpace();
-					addWhereCondition(t.children[0], currentPrecedency, dialect, res);
-					break;
-				case OperatorType.IS_NULL:
-				case OperatorType.IS_NOT_NULL:
-					addWhereCondition(t.children[0], currentPrecedency, dialect, res);
-					res.appendSpace();
-					res.appendSQL(t.text);
-					res.appendSpace();
-					break;
-				case OperatorType.BETWEEN:
-					if (!needBraces)
-						res.appendSpace();
-					addWhereCondition(t.children[0], currentPrecedency, dialect, res);
-					res.appendSQL(" BETWEEN ");
-					addWhereCondition(t.children[1], currentPrecedency, dialect, res);
-					res.appendSQL(" AND ");
-					addWhereCondition(t.children[2], currentPrecedency, dialect, res);
-					break;
+            int currentPrecedency = operatorPrecedency(t.operator);
+            bool needBraces = currentPrecedency < basePrecedency;
+            if (needBraces)
+                res.appendSQL("(");
+            switch(t.operator) {
+                case OperatorType.LIKE:
+                case OperatorType.EQ:
+                case OperatorType.NE:
+                case OperatorType.LT:
+                case OperatorType.GT:
+                case OperatorType.LE:
+                case OperatorType.GE:
+                case OperatorType.MUL:
+                case OperatorType.ADD:
+                case OperatorType.SUB:
+                case OperatorType.DIV:
+                case OperatorType.AND:
+                case OperatorType.OR:
+                case OperatorType.IDIV:
+                case OperatorType.MOD:
+                    // binary op
+                    if (!needBraces)
+                        res.appendSpace();
+                    addWhereCondition(t.children[0], currentPrecedency, dialect, res);
+                    res.appendSpace();
+                    res.appendSQL(t.text);
+                    res.appendSpace();
+                    addWhereCondition(t.children[1], currentPrecedency, dialect, res);
+                    break;
+                case OperatorType.UNARY_PLUS:
+                case OperatorType.UNARY_MINUS:
+                case OperatorType.NOT:
+                    // unary op
+                    if (!needBraces)
+                        res.appendSpace();
+                    res.appendSQL(t.text);
+                    res.appendSpace();
+                    addWhereCondition(t.children[0], currentPrecedency, dialect, res);
+                    break;
+                case OperatorType.IS_NULL:
+                case OperatorType.IS_NOT_NULL:
+                    addWhereCondition(t.children[0], currentPrecedency, dialect, res);
+                    res.appendSpace();
+                    res.appendSQL(t.text);
+                    res.appendSpace();
+                    break;
+                case OperatorType.BETWEEN:
+                    if (!needBraces)
+                        res.appendSpace();
+                    addWhereCondition(t.children[0], currentPrecedency, dialect, res);
+                    res.appendSQL(" BETWEEN ");
+                    addWhereCondition(t.children[1], currentPrecedency, dialect, res);
+                    res.appendSQL(" AND ");
+                    addWhereCondition(t.children[2], currentPrecedency, dialect, res);
+                    break;
                 case OperatorType.IN:
                     if (!needBraces)
                         res.appendSpace();
@@ -1107,662 +1107,662 @@ class QueryParser {
                     addWhereCondition(t.children[1], currentPrecedency, dialect, res);
                     res.appendSQL(")");
                     break;
-				case OperatorType.IS:
-				default:
-					enforceHelper!QuerySyntaxException(false, "Unexpected operator" ~ errorContext(t));
-					break;
-			}
-			if (needBraces)
-				res.appendSQL(")");
-		}
-	}
-	
-	void addWhereSQL(Dialect dialect, ParsedQuery res) {
-		if (whereClause is null)
-			return;
-		res.appendSpace();
-		res.appendSQL("WHERE ");
-		addWhereCondition(whereClause, 0, dialect, res);
-	}
-	
-	void addOrderBySQL(Dialect dialect, ParsedQuery res) {
-		if (orderByClause.length == 0)
-			return;
-		res.appendSpace();
-		res.appendSQL("ORDER BY ");
-		bool first = true;
-		// individual fields specified
-		foreach(a; orderByClause) {
-			string fieldName = a.prop.columnName;
-			string tableName = a.from.sqlAlias;
-			if (!first) {
-				res.appendSQL(", ");
-			} else 
-				first = false;
-			res.appendSQL(tableName ~ "." ~ dialect.quoteIfNeeded(fieldName));
-			if (!a.asc)
-				res.appendSQL(" DESC");
-		}
-	}
-	
-	ParsedQuery makeSQL(Dialect dialect) {
-		ParsedQuery res = new ParsedQuery(query);
-		addSelectSQL(dialect, res);
-		addFromSQL(dialect, res);
-		addWhereSQL(dialect, res);
-		addOrderBySQL(dialect, res);
-		return res;
-	}
-	
+                case OperatorType.IS:
+                default:
+                    enforceHelper!QuerySyntaxException(false, "Unexpected operator" ~ errorContext(t));
+                    break;
+            }
+            if (needBraces)
+                res.appendSQL(")");
+        }
+    }
+
+    void addWhereSQL(Dialect dialect, ParsedQuery res) {
+        if (whereClause is null)
+            return;
+        res.appendSpace();
+        res.appendSQL("WHERE ");
+        addWhereCondition(whereClause, 0, dialect, res);
+    }
+
+    void addOrderBySQL(Dialect dialect, ParsedQuery res) {
+        if (orderByClause.length == 0)
+            return;
+        res.appendSpace();
+        res.appendSQL("ORDER BY ");
+        bool first = true;
+        // individual fields specified
+        foreach(a; orderByClause) {
+            string fieldName = a.prop.columnName;
+            string tableName = a.from.sqlAlias;
+            if (!first) {
+                res.appendSQL(", ");
+            } else
+                first = false;
+            res.appendSQL(tableName ~ "." ~ dialect.quoteIfNeeded(fieldName));
+            if (!a.asc)
+                res.appendSQL(" DESC");
+        }
+    }
+
+    ParsedQuery makeSQL(Dialect dialect) {
+        ParsedQuery res = new ParsedQuery(query);
+        addSelectSQL(dialect, res);
+        addFromSQL(dialect, res);
+        addWhereSQL(dialect, res);
+        addOrderBySQL(dialect, res);
+        return res;
+    }
+
 }
 
 enum KeywordType {
-	NONE,
-	SELECT,
-	FROM,
-	WHERE,
-	ORDER,
-	BY,
-	ASC,
-	DESC,
-	JOIN,
-	INNER,
-	OUTER,
-	LEFT,
-	RIGHT,
+    NONE,
+    SELECT,
+    FROM,
+    WHERE,
+    ORDER,
+    BY,
+    ASC,
+    DESC,
+    JOIN,
+    INNER,
+    OUTER,
+    LEFT,
+    RIGHT,
     FETCH,
     AS,
-	LIKE,
-	IN,
-	IS,
-	NOT,
-	NULL,
-	AND,
-	OR,
-	BETWEEN,
-	DIV,
-	MOD,
+    LIKE,
+    IN,
+    IS,
+    NOT,
+    NULL,
+    AND,
+    OR,
+    BETWEEN,
+    DIV,
+    MOD,
 }
 
 KeywordType isKeyword(string str) {
-	return isKeyword(str.dup);
+    return isKeyword(str.dup);
 }
 
 KeywordType isKeyword(char[] str) {
-	char[] s = toUpper(str);
-	if (s=="SELECT") return KeywordType.SELECT;
-	if (s=="FROM") return KeywordType.FROM;
-	if (s=="WHERE") return KeywordType.WHERE;
-	if (s=="ORDER") return KeywordType.ORDER;
-	if (s=="BY") return KeywordType.BY;
-	if (s=="ASC") return KeywordType.ASC;
-	if (s=="DESC") return KeywordType.DESC;
-	if (s=="JOIN") return KeywordType.JOIN;
-	if (s=="INNER") return KeywordType.INNER;
-	if (s=="OUTER") return KeywordType.OUTER;
-	if (s=="LEFT") return KeywordType.LEFT;
-	if (s=="RIGHT") return KeywordType.RIGHT;
+    char[] s = toUpper(str);
+    if (s=="SELECT") return KeywordType.SELECT;
+    if (s=="FROM") return KeywordType.FROM;
+    if (s=="WHERE") return KeywordType.WHERE;
+    if (s=="ORDER") return KeywordType.ORDER;
+    if (s=="BY") return KeywordType.BY;
+    if (s=="ASC") return KeywordType.ASC;
+    if (s=="DESC") return KeywordType.DESC;
+    if (s=="JOIN") return KeywordType.JOIN;
+    if (s=="INNER") return KeywordType.INNER;
+    if (s=="OUTER") return KeywordType.OUTER;
+    if (s=="LEFT") return KeywordType.LEFT;
+    if (s=="RIGHT") return KeywordType.RIGHT;
     if (s=="FETCH") return KeywordType.FETCH;
     if (s=="LIKE") return KeywordType.LIKE;
-	if (s=="IN") return KeywordType.IN;
-	if (s=="IS") return KeywordType.IS;
-	if (s=="NOT") return KeywordType.NOT;
-	if (s=="NULL") return KeywordType.NULL;
-	if (s=="AS") return KeywordType.AS;
-	if (s=="AND") return KeywordType.AND;
-	if (s=="OR") return KeywordType.OR;
-	if (s=="BETWEEN") return KeywordType.BETWEEN;
-	if (s=="DIV") return KeywordType.DIV;
-	if (s=="MOD") return KeywordType.MOD;
-	return KeywordType.NONE;
+    if (s=="IN") return KeywordType.IN;
+    if (s=="IS") return KeywordType.IS;
+    if (s=="NOT") return KeywordType.NOT;
+    if (s=="NULL") return KeywordType.NULL;
+    if (s=="AS") return KeywordType.AS;
+    if (s=="AND") return KeywordType.AND;
+    if (s=="OR") return KeywordType.OR;
+    if (s=="BETWEEN") return KeywordType.BETWEEN;
+    if (s=="DIV") return KeywordType.DIV;
+    if (s=="MOD") return KeywordType.MOD;
+    return KeywordType.NONE;
 }
 
 unittest {
-	assert(isKeyword("Null") == KeywordType.NULL);
-	assert(isKeyword("from") == KeywordType.FROM);
-	assert(isKeyword("SELECT") == KeywordType.SELECT);
-	assert(isKeyword("blabla") == KeywordType.NONE);
+    assert(isKeyword("Null") == KeywordType.NULL);
+    assert(isKeyword("from") == KeywordType.FROM);
+    assert(isKeyword("SELECT") == KeywordType.SELECT);
+    assert(isKeyword("blabla") == KeywordType.NONE);
 }
 
 enum OperatorType {
-	NONE,
-	
-	// symbolic
-	EQ, // ==
-	NE, // != <>
-	LT, // <
-	GT, // >
-	LE, // <=
-	GE, // >=
-	MUL,// *
-	ADD,// +
-	SUB,// -
-	DIV,// /
-	
-	// from keywords
-	LIKE,
-	IN,
-	IS,
-	NOT,
-	AND,
-	OR,
-	BETWEEN,
-	IDIV,
-	MOD,
-	
-	UNARY_PLUS,
-	UNARY_MINUS,
-	
-	IS_NULL,
-	IS_NOT_NULL,
+    NONE,
+
+    // symbolic
+    EQ, // ==
+    NE, // != <>
+    LT, // <
+    GT, // >
+    LE, // <=
+    GE, // >=
+    MUL,// *
+    ADD,// +
+    SUB,// -
+    DIV,// /
+
+    // from keywords
+    LIKE,
+    IN,
+    IS,
+    NOT,
+    AND,
+    OR,
+    BETWEEN,
+    IDIV,
+    MOD,
+
+    UNARY_PLUS,
+    UNARY_MINUS,
+
+    IS_NULL,
+    IS_NOT_NULL,
 }
 
 OperatorType isOperator(KeywordType t) {
-	switch (t) {
-		case KeywordType.LIKE: return OperatorType.LIKE;
-		case KeywordType.IN: return OperatorType.IN;
-		case KeywordType.IS: return OperatorType.IS;
-		case KeywordType.NOT: return OperatorType.NOT;
-		case KeywordType.AND: return OperatorType.AND;
-		case KeywordType.OR: return OperatorType.OR;
-		case KeywordType.BETWEEN: return OperatorType.BETWEEN;
-		case KeywordType.DIV: return OperatorType.IDIV;
-		case KeywordType.MOD: return OperatorType.MOD;
-		default: return OperatorType.NONE;
-	}
+    switch (t) {
+        case KeywordType.LIKE: return OperatorType.LIKE;
+        case KeywordType.IN: return OperatorType.IN;
+        case KeywordType.IS: return OperatorType.IS;
+        case KeywordType.NOT: return OperatorType.NOT;
+        case KeywordType.AND: return OperatorType.AND;
+        case KeywordType.OR: return OperatorType.OR;
+        case KeywordType.BETWEEN: return OperatorType.BETWEEN;
+        case KeywordType.DIV: return OperatorType.IDIV;
+        case KeywordType.MOD: return OperatorType.MOD;
+        default: return OperatorType.NONE;
+    }
 }
 
 int operatorPrecedency(OperatorType t) {
-	switch(t) {
-		case OperatorType.EQ: return 5; // ==
-		case OperatorType.NE: return 5; // != <>
-		case OperatorType.LT: return 5; // <
-		case OperatorType.GT: return 5; // >
-		case OperatorType.LE: return 5; // <=
-		case OperatorType.GE: return 5; // >=
-		case OperatorType.MUL: return 10; // *
-		case OperatorType.ADD: return 9; // +
-		case OperatorType.SUB: return 9; // -
-		case OperatorType.DIV: return 10; // /
-			// from keywords
-		case OperatorType.LIKE: return 11;
-		case OperatorType.IN: return 12;
-		case OperatorType.IS: return 13;
-		case OperatorType.NOT: return 6; // ???
-		case OperatorType.AND: return 4;
-		case OperatorType.OR:  return 3;
-		case OperatorType.BETWEEN: return 7; // ???
-		case OperatorType.IDIV: return 10;
-		case OperatorType.MOD: return 10;
-		case OperatorType.UNARY_PLUS: return 15;
-		case OperatorType.UNARY_MINUS: return 15;
-		case OperatorType.IS_NULL: return 15;
-		case OperatorType.IS_NOT_NULL: return 15;
-		default: return -1;
-	}
+    switch(t) {
+        case OperatorType.EQ: return 5; // ==
+        case OperatorType.NE: return 5; // != <>
+        case OperatorType.LT: return 5; // <
+        case OperatorType.GT: return 5; // >
+        case OperatorType.LE: return 5; // <=
+        case OperatorType.GE: return 5; // >=
+        case OperatorType.MUL: return 10; // *
+        case OperatorType.ADD: return 9; // +
+        case OperatorType.SUB: return 9; // -
+        case OperatorType.DIV: return 10; // /
+            // from keywords
+        case OperatorType.LIKE: return 11;
+        case OperatorType.IN: return 12;
+        case OperatorType.IS: return 13;
+        case OperatorType.NOT: return 6; // ???
+        case OperatorType.AND: return 4;
+        case OperatorType.OR:  return 3;
+        case OperatorType.BETWEEN: return 7; // ???
+        case OperatorType.IDIV: return 10;
+        case OperatorType.MOD: return 10;
+        case OperatorType.UNARY_PLUS: return 15;
+        case OperatorType.UNARY_MINUS: return 15;
+        case OperatorType.IS_NULL: return 15;
+        case OperatorType.IS_NOT_NULL: return 15;
+        default: return -1;
+    }
 }
 
 OperatorType isOperator(string s, ref int i) {
-	int len = cast(int)s.length;
-	char ch = s[i];
-	char ch2 = i < len - 1 ? s[i + 1] : 0;
-	//char ch3 = i < len - 2 ? s[i + 2] : 0;
-	if (ch == '=' && ch2 == '=') { i++; return OperatorType.EQ; } // ==
-	if (ch == '!' && ch2 == '=') { i++; return OperatorType.NE; } // !=
-	if (ch == '<' && ch2 == '>') { i++; return OperatorType.NE; } // <>
-	if (ch == '<' && ch2 == '=') { i++; return OperatorType.LE; } // <=
-	if (ch == '>' && ch2 == '=') { i++; return OperatorType.GE; } // >=
-	if (ch == '=') return OperatorType.EQ; // =
-	if (ch == '<') return OperatorType.LT; // <
-	if (ch == '>') return OperatorType.GT; // <
-	if (ch == '*') return OperatorType.MUL; // <
-	if (ch == '+') return OperatorType.ADD; // <
-	if (ch == '-') return OperatorType.SUB; // <
-	if (ch == '/') return OperatorType.DIV; // <
-	return OperatorType.NONE;
+    int len = cast(int)s.length;
+    char ch = s[i];
+    char ch2 = i < len - 1 ? s[i + 1] : 0;
+    //char ch3 = i < len - 2 ? s[i + 2] : 0;
+    if (ch == '=' && ch2 == '=') { i++; return OperatorType.EQ; } // ==
+    if (ch == '!' && ch2 == '=') { i++; return OperatorType.NE; } // !=
+    if (ch == '<' && ch2 == '>') { i++; return OperatorType.NE; } // <>
+    if (ch == '<' && ch2 == '=') { i++; return OperatorType.LE; } // <=
+    if (ch == '>' && ch2 == '=') { i++; return OperatorType.GE; } // >=
+    if (ch == '=') return OperatorType.EQ; // =
+    if (ch == '<') return OperatorType.LT; // <
+    if (ch == '>') return OperatorType.GT; // <
+    if (ch == '*') return OperatorType.MUL; // <
+    if (ch == '+') return OperatorType.ADD; // <
+    if (ch == '-') return OperatorType.SUB; // <
+    if (ch == '/') return OperatorType.DIV; // <
+    return OperatorType.NONE;
 }
 
 
 enum TokenType {
-	Keyword,      // WHERE
-	Ident,        // ident
-	Number,       // 25   13.5e-10
-	String,       // 'string'
-	Operator,     // == != <= >= < > + - * /
-	Dot,          // .
-	OpenBracket,  // (
-	CloseBracket, // )
-	Comma,        // ,
-	Entity,       // entity name
-	Field,        // field name of some entity
-	Alias,        // alias name of some entity
-	Parameter,    // ident after :
-	// types of compound AST nodes
-	Expression,   // any expression
-	Braces,       // ( tokens )
-	CommaDelimitedList, // tokens, ... , tokens
-	OpExpr, // operator expression; current token == operator, children = params
+    Keyword,      // WHERE
+    Ident,        // ident
+    Number,       // 25   13.5e-10
+    String,       // 'string'
+    Operator,     // == != <= >= < > + - * /
+    Dot,          // .
+    OpenBracket,  // (
+    CloseBracket, // )
+    Comma,        // ,
+    Entity,       // entity name
+    Field,        // field name of some entity
+    Alias,        // alias name of some entity
+    Parameter,    // ident after :
+    // types of compound AST nodes
+    Expression,   // any expression
+    Braces,       // ( tokens )
+    CommaDelimitedList, // tokens, ... , tokens
+    OpExpr, // operator expression; current token == operator, children = params
 }
 
 class Token {
-	int pos;
-	TokenType type;
-	KeywordType keyword = KeywordType.NONE;
-	OperatorType operator = OperatorType.NONE;
-	string text;
-	string spaceAfter;
-	EntityInfo entity;
+    int pos;
+    TokenType type;
+    KeywordType keyword = KeywordType.NONE;
+    OperatorType operator = OperatorType.NONE;
+    string text;
+    string spaceAfter;
+    EntityInfo entity;
     PropertyInfo field;
-	FromClauseItem from;
+    FromClauseItem from;
     // Embedded fields may have a prefix derived from `@Embedded` annotations on properties that
     // contain them.
     string columnPrefix;
-	Token[] children;
-	this(int pos, TokenType type, string text) {
-		this.pos = pos;
-		this.type = type;
-		this.text = text;
-	}
-	this(int pos, KeywordType keyword, string text) {
-		this.pos = pos;
-		this.type = TokenType.Keyword;
-		this.keyword = keyword;
-		this.text = text;
-	}
-	this(int pos, OperatorType op, string text) {
-		this.pos = pos;
-		this.type = TokenType.Operator;
-		this.operator = op;
-		this.text = text;
-	}
-	this(int pos, TokenType type, Token[] base, int start, int end) {
-		this.pos = pos;
-		this.type = type;
-		this.children = new Token[end - start];
-		for (int i = start; i < end; i++)
-			children[i - start] = base[i];
-	}
-	// unary operator expression
-	this(int pos, OperatorType type, string text, Token right) {
-		this.pos = pos;
-		this.type = TokenType.OpExpr;
-		this.operator = type;
-		this.text = text;
-		this.children = new Token[1];
-		this.children[0] = right;
-	}
-	// binary operator expression
-	this(int pos, OperatorType type, string text, Token left, Token right) {
-		this.pos = pos;
-		this.type = TokenType.OpExpr;
-		this.text = text;
-		this.operator = type;
-		this.children = new Token[2];
-		this.children[0] = left;
-		this.children[1] = right;
-	}
-	bool isExpression() {
-		return type==TokenType.Expression || type==TokenType.Braces || type==TokenType.OpExpr || type==TokenType.Parameter 
-			|| type==TokenType.Field || type==TokenType.String || type==TokenType.Number;
-	}
-	bool isCompound() {
-		return this.type >= TokenType.Expression;
-	}
-	string dump(int level) {
-		string res;
-		for (int i=0; i<level; i++)
-			res ~= "    ";
-		res ~= toString() ~ "\n";
-		foreach (c; children)
-			res ~= c.dump(level + 1);
-		return res;
-	}
-	override string toString() {
-		switch (type) {
-			case TokenType.Keyword:      // WHERE
-			case TokenType.Ident: return "`" ~ text ~ "`";        // ident
-			case TokenType.Number: return "" ~ text;       // 25   13.5e-10
-			case TokenType.String: return "'" ~ text ~ "'";       // 'string'
-			case TokenType.Operator: return "op:" ~ text;     // == != <= >= < > + - * /
-			case TokenType.Dot: return ".";          // .
-			case TokenType.OpenBracket: return "(";  // (
-			case TokenType.CloseBracket: return ")"; // )
-			case TokenType.Comma: return ",";        // ,
-			case TokenType.Entity: return "entity: " ~ entity.name;       // entity name
-			case TokenType.Field: return from.entityAlias ~ "." ~ field.propertyName;        // field name of some entity
-			case TokenType.Alias: return "alias: " ~ text;        // alias name of some entity
-			case TokenType.Parameter: return ":" ~ text;    // ident after :
-				// types of compound AST nodes
-			case TokenType.Expression: return "expr";   // any expression
-			case TokenType.Braces: return "()";       // ( tokens )
-			case TokenType.CommaDelimitedList: return ",,,"; // tokens, ... , tokens
-			case TokenType.OpExpr: return "" ~ text;
-			default: return "UNKNOWN";
-		}
-	}
-	
+    Token[] children;
+    this(int pos, TokenType type, string text) {
+        this.pos = pos;
+        this.type = type;
+        this.text = text;
+    }
+    this(int pos, KeywordType keyword, string text) {
+        this.pos = pos;
+        this.type = TokenType.Keyword;
+        this.keyword = keyword;
+        this.text = text;
+    }
+    this(int pos, OperatorType op, string text) {
+        this.pos = pos;
+        this.type = TokenType.Operator;
+        this.operator = op;
+        this.text = text;
+    }
+    this(int pos, TokenType type, Token[] base, int start, int end) {
+        this.pos = pos;
+        this.type = type;
+        this.children = new Token[end - start];
+        for (int i = start; i < end; i++)
+            children[i - start] = base[i];
+    }
+    // unary operator expression
+    this(int pos, OperatorType type, string text, Token right) {
+        this.pos = pos;
+        this.type = TokenType.OpExpr;
+        this.operator = type;
+        this.text = text;
+        this.children = new Token[1];
+        this.children[0] = right;
+    }
+    // binary operator expression
+    this(int pos, OperatorType type, string text, Token left, Token right) {
+        this.pos = pos;
+        this.type = TokenType.OpExpr;
+        this.text = text;
+        this.operator = type;
+        this.children = new Token[2];
+        this.children[0] = left;
+        this.children[1] = right;
+    }
+    bool isExpression() {
+        return type==TokenType.Expression || type==TokenType.Braces || type==TokenType.OpExpr || type==TokenType.Parameter
+            || type==TokenType.Field || type==TokenType.String || type==TokenType.Number;
+    }
+    bool isCompound() {
+        return this.type >= TokenType.Expression;
+    }
+    string dump(int level) {
+        string res;
+        for (int i=0; i<level; i++)
+            res ~= "    ";
+        res ~= toString() ~ "\n";
+        foreach (c; children)
+            res ~= c.dump(level + 1);
+        return res;
+    }
+    override string toString() {
+        switch (type) {
+            case TokenType.Keyword:      // WHERE
+            case TokenType.Ident: return "`" ~ text ~ "`";        // ident
+            case TokenType.Number: return "" ~ text;       // 25   13.5e-10
+            case TokenType.String: return "'" ~ text ~ "'";       // 'string'
+            case TokenType.Operator: return "op:" ~ text;     // == != <= >= < > + - * /
+            case TokenType.Dot: return ".";          // .
+            case TokenType.OpenBracket: return "(";  // (
+            case TokenType.CloseBracket: return ")"; // )
+            case TokenType.Comma: return ",";        // ,
+            case TokenType.Entity: return "entity: " ~ entity.name;       // entity name
+            case TokenType.Field: return from.entityAlias ~ "." ~ field.propertyName;        // field name of some entity
+            case TokenType.Alias: return "alias: " ~ text;        // alias name of some entity
+            case TokenType.Parameter: return ":" ~ text;    // ident after :
+                // types of compound AST nodes
+            case TokenType.Expression: return "expr";   // any expression
+            case TokenType.Braces: return "()";       // ( tokens )
+            case TokenType.CommaDelimitedList: return ",,,"; // tokens, ... , tokens
+            case TokenType.OpExpr: return "" ~ text;
+            default: return "UNKNOWN";
+        }
+    }
+
 }
 
 Token[] tokenize(string s) {
-	Token[] res;
-	int startpos = 0;
-	int state = 0;
-	int len = cast(int)s.length;
-	for (int i=0; i<len; i++) {
-		char ch = s[i];
-		char ch2 = i < len - 1 ? s[i + 1] : 0;
-		char ch3 = i < len - 2 ? s[i + 2] : 0;
-		string text;
-		bool quotedIdent = ch == '`';
-		startpos = i;
-		OperatorType op = isOperator(s, i);
-		if (op != OperatorType.NONE) {
-			// operator
-			res ~= new Token(startpos, op, s[startpos .. i + 1]);
-		} else if (ch == ':' && (isAlpha(ch2) || ch2=='_')) {
-			// parameter name
-			i++;
-			// && state == 0
-			for(int j=i; j<len; j++) {
-				if (isAlphaNum(s[j]) || s[j] == '_') {
-					text ~= s[j];
-					i = j;
-				} else {
-					break;
-				}
-			}
-			enforceHelper!QuerySyntaxException(text.length > 0, "Invalid parameter name near " ~ cast(string)s[startpos .. $]);
-			res ~= new Token(startpos, TokenType.Parameter, text);
-		} else if (isAlpha(ch) || ch=='_' || quotedIdent) {
-			// identifier or keyword
-			if (quotedIdent) {
-				i++;
-				enforceHelper!QuerySyntaxException(i < len - 1, "Invalid quoted identifier near " ~ cast(string)s[startpos .. $]);
-			}
-			// && state == 0
-			for(int j=i; j<len; j++) {
-				if (isAlphaNum(s[j]) || s[j] == '_') {
-					text ~= s[j];
-					i = j;
-				} else {
-					break;
-				}
-			}
-			enforceHelper!QuerySyntaxException(text.length > 0, "Invalid quoted identifier near " ~ cast(string)s[startpos .. $]);
-			if (quotedIdent) {
-				enforceHelper!QuerySyntaxException(i < len - 1 && s[i + 1] == '`', "Invalid quoted identifier near " ~ cast(string)s[startpos .. $]);
-				i++;
-			}
-			KeywordType keywordId = isKeyword(text);
-			if (keywordId != KeywordType.NONE && !quotedIdent) {
-				OperatorType keywordOp = isOperator(keywordId);
-				if (keywordOp != OperatorType.NONE)
-					res ~= new Token(startpos, keywordOp, text); // operator keyword
-				else
-					res ~= new Token(startpos, keywordId, text);
-			} else
-				res ~= new Token(startpos, TokenType.Ident, text);
-		} else if (isWhite(ch)) {
-			// whitespace
-			for(int j=i; j<len; j++) {
-				if (isWhite(s[j])) {
-					text ~= s[j];
-					i = j;
-				} else {
-					break;
-				}
-			}
-			// don't add whitespace to lexer results as separate token
-			// add as spaceAfter
-			if (res.length > 0) {
-				res[$ - 1].spaceAfter = text;
-			}
-		} else if (ch == '\'') {
-			// string constant
-			i++;
-			for(int j=i; j<len; j++) {
-				if (s[j] != '\'') {
-					text ~= s[j];
-					i = j;
-				} else {
-					break;
-				}
-			}
-			enforceHelper!QuerySyntaxException(i < len - 1 && s[i + 1] == '\'', "Unfinished string near " ~ cast(string)s[startpos .. $]);
-			i++;
-			res ~= new Token(startpos, TokenType.String, text);
-		} else if (isDigit(ch) || (ch == '.' && isDigit(ch2))) {
-			// numeric constant
-			if (ch == '.') {
-				// .25
-				text ~= '.';
-				i++;
-				for(int j = i; j<len; j++) {
-					if (isDigit(s[j])) {
-						text ~= s[j];
-						i = j;
-					} else {
-						break;
-					}
-				}
-			} else {
-				// 123
-				for(int j=i; j<len; j++) {
-					if (isDigit(s[j])) {
-						text ~= s[j];
-						i = j;
-					} else {
-						break;
-					}
-				}
-				// .25
-				if (i < len - 1 && s[i + 1] == '.') {
-					text ~= '.';
-					i++;
-					for(int j = i; j<len; j++) {
-						if (isDigit(s[j])) {
-							text ~= s[j];
-							i = j;
-						} else {
-							break;
-						}
-					}
-				}
-			}
-			if (i < len - 1 && std.ascii.toLower(s[i + 1]) == 'e') {
-				text ~= s[i+1];
-				i++;
-				if (i < len - 1 && (s[i + 1] == '-' || s[i + 1] == '+')) {
-					text ~= s[i+1];
-					i++;
-				}
-				enforceHelper!QuerySyntaxException(i < len - 1 && isDigit(s[i]), "Invalid number near " ~ cast(string)s[startpos .. $]);
-				for(int j = i; j<len; j++) {
-					if (isDigit(s[j])) {
-						text ~= s[j];
-						i = j;
-					} else {
-						break;
-					}
-				}
-			}
-			enforceHelper!QuerySyntaxException(i >= len - 1 || !isAlpha(s[i]), "Invalid number near " ~ cast(string)s[startpos .. $]);
-			res ~= new Token(startpos, TokenType.Number, text);
-		} else if (ch == '.') {
-			res ~= new Token(startpos, TokenType.Dot, ".");
-		} else if (ch == '(') {
-			res ~= new Token(startpos, TokenType.OpenBracket, "(");
-		} else if (ch == ')') {
-			res ~= new Token(startpos, TokenType.CloseBracket, ")");
-		} else if (ch == ',') {
-			res ~= new Token(startpos, TokenType.Comma, ",");
-		} else {
-			enforceHelper!QuerySyntaxException(false, "Invalid character near " ~ cast(string)s[startpos .. $]);
-		}
-	}
-	return res;
+    Token[] res;
+    int startpos = 0;
+    int state = 0;
+    int len = cast(int)s.length;
+    for (int i=0; i<len; i++) {
+        char ch = s[i];
+        char ch2 = i < len - 1 ? s[i + 1] : 0;
+        char ch3 = i < len - 2 ? s[i + 2] : 0;
+        string text;
+        bool quotedIdent = ch == '`';
+        startpos = i;
+        OperatorType op = isOperator(s, i);
+        if (op != OperatorType.NONE) {
+            // operator
+            res ~= new Token(startpos, op, s[startpos .. i + 1]);
+        } else if (ch == ':' && (isAlpha(ch2) || ch2=='_')) {
+            // parameter name
+            i++;
+            // && state == 0
+            for(int j=i; j<len; j++) {
+                if (isAlphaNum(s[j]) || s[j] == '_') {
+                    text ~= s[j];
+                    i = j;
+                } else {
+                    break;
+                }
+            }
+            enforceHelper!QuerySyntaxException(text.length > 0, "Invalid parameter name near " ~ cast(string)s[startpos .. $]);
+            res ~= new Token(startpos, TokenType.Parameter, text);
+        } else if (isAlpha(ch) || ch=='_' || quotedIdent) {
+            // identifier or keyword
+            if (quotedIdent) {
+                i++;
+                enforceHelper!QuerySyntaxException(i < len - 1, "Invalid quoted identifier near " ~ cast(string)s[startpos .. $]);
+            }
+            // && state == 0
+            for(int j=i; j<len; j++) {
+                if (isAlphaNum(s[j]) || s[j] == '_') {
+                    text ~= s[j];
+                    i = j;
+                } else {
+                    break;
+                }
+            }
+            enforceHelper!QuerySyntaxException(text.length > 0, "Invalid quoted identifier near " ~ cast(string)s[startpos .. $]);
+            if (quotedIdent) {
+                enforceHelper!QuerySyntaxException(i < len - 1 && s[i + 1] == '`', "Invalid quoted identifier near " ~ cast(string)s[startpos .. $]);
+                i++;
+            }
+            KeywordType keywordId = isKeyword(text);
+            if (keywordId != KeywordType.NONE && !quotedIdent) {
+                OperatorType keywordOp = isOperator(keywordId);
+                if (keywordOp != OperatorType.NONE)
+                    res ~= new Token(startpos, keywordOp, text); // operator keyword
+                else
+                    res ~= new Token(startpos, keywordId, text);
+            } else
+                res ~= new Token(startpos, TokenType.Ident, text);
+        } else if (isWhite(ch)) {
+            // whitespace
+            for(int j=i; j<len; j++) {
+                if (isWhite(s[j])) {
+                    text ~= s[j];
+                    i = j;
+                } else {
+                    break;
+                }
+            }
+            // don't add whitespace to lexer results as separate token
+            // add as spaceAfter
+            if (res.length > 0) {
+                res[$ - 1].spaceAfter = text;
+            }
+        } else if (ch == '\'') {
+            // string constant
+            i++;
+            for(int j=i; j<len; j++) {
+                if (s[j] != '\'') {
+                    text ~= s[j];
+                    i = j;
+                } else {
+                    break;
+                }
+            }
+            enforceHelper!QuerySyntaxException(i < len - 1 && s[i + 1] == '\'', "Unfinished string near " ~ cast(string)s[startpos .. $]);
+            i++;
+            res ~= new Token(startpos, TokenType.String, text);
+        } else if (isDigit(ch) || (ch == '.' && isDigit(ch2))) {
+            // numeric constant
+            if (ch == '.') {
+                // .25
+                text ~= '.';
+                i++;
+                for(int j = i; j<len; j++) {
+                    if (isDigit(s[j])) {
+                        text ~= s[j];
+                        i = j;
+                    } else {
+                        break;
+                    }
+                }
+            } else {
+                // 123
+                for(int j=i; j<len; j++) {
+                    if (isDigit(s[j])) {
+                        text ~= s[j];
+                        i = j;
+                    } else {
+                        break;
+                    }
+                }
+                // .25
+                if (i < len - 1 && s[i + 1] == '.') {
+                    text ~= '.';
+                    i++;
+                    for(int j = i; j<len; j++) {
+                        if (isDigit(s[j])) {
+                            text ~= s[j];
+                            i = j;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+            if (i < len - 1 && std.ascii.toLower(s[i + 1]) == 'e') {
+                text ~= s[i+1];
+                i++;
+                if (i < len - 1 && (s[i + 1] == '-' || s[i + 1] == '+')) {
+                    text ~= s[i+1];
+                    i++;
+                }
+                enforceHelper!QuerySyntaxException(i < len - 1 && isDigit(s[i]), "Invalid number near " ~ cast(string)s[startpos .. $]);
+                for(int j = i; j<len; j++) {
+                    if (isDigit(s[j])) {
+                        text ~= s[j];
+                        i = j;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            enforceHelper!QuerySyntaxException(i >= len - 1 || !isAlpha(s[i]), "Invalid number near " ~ cast(string)s[startpos .. $]);
+            res ~= new Token(startpos, TokenType.Number, text);
+        } else if (ch == '.') {
+            res ~= new Token(startpos, TokenType.Dot, ".");
+        } else if (ch == '(') {
+            res ~= new Token(startpos, TokenType.OpenBracket, "(");
+        } else if (ch == ')') {
+            res ~= new Token(startpos, TokenType.CloseBracket, ")");
+        } else if (ch == ',') {
+            res ~= new Token(startpos, TokenType.Comma, ",");
+        } else {
+            enforceHelper!QuerySyntaxException(false, "Invalid character near " ~ cast(string)s[startpos .. $]);
+        }
+    }
+    return res;
 }
 
 unittest {
-	Token[] tokens;
-	tokens = tokenize("SELECT a From User a where a.flags = 12 AND a.name='john' ORDER BY a.idx ASC");
-	assert(tokens.length == 23);
-	assert(tokens[0].type == TokenType.Keyword);
-	assert(tokens[2].type == TokenType.Keyword);
-	assert(tokens[5].type == TokenType.Keyword);
-	assert(tokens[5].text == "where");
-	assert(tokens[10].type == TokenType.Number);
-	assert(tokens[10].text == "12");
-	assert(tokens[16].type == TokenType.String);
-	assert(tokens[16].text == "john");
-	assert(tokens[22].type == TokenType.Keyword);
-	assert(tokens[22].text == "ASC");
+    Token[] tokens;
+    tokens = tokenize("SELECT a From User a where a.flags = 12 AND a.name='john' ORDER BY a.idx ASC");
+    assert(tokens.length == 23);
+    assert(tokens[0].type == TokenType.Keyword);
+    assert(tokens[2].type == TokenType.Keyword);
+    assert(tokens[5].type == TokenType.Keyword);
+    assert(tokens[5].text == "where");
+    assert(tokens[10].type == TokenType.Number);
+    assert(tokens[10].text == "12");
+    assert(tokens[16].type == TokenType.String);
+    assert(tokens[16].text == "john");
+    assert(tokens[22].type == TokenType.Keyword);
+    assert(tokens[22].text == "ASC");
 }
 
 class ParameterValues {
-	Variant[string] values;
-	int[][string]params;
-	int[string]unboundParams;
-	this(int[][string]params) {
-		this.params = params;
-		foreach(key, value; params) {
-			unboundParams[key] = 1;
-		}
-	}
-	void setParameter(string name, Variant value) {
+    Variant[string] values;
+    int[][string]params;
+    int[string]unboundParams;
+    this(int[][string]params) {
+        this.params = params;
+        foreach(key, value; params) {
+            unboundParams[key] = 1;
+        }
+    }
+    void setParameter(string name, Variant value) {
         enforceHelper!QueryParameterException((name in params) !is null, "Attempting to set unknown parameter " ~ name);
-		unboundParams.remove(name);
-		values[name] = value;
-	}
-	void checkAllParametersSet() {
-		if (unboundParams.length == 0)
-			return;
-		string list;
-		foreach(key, value; unboundParams) {
-			if (list.length > 0)
-				list ~= ", ";
-			list ~= key;
-		}
+        unboundParams.remove(name);
+        values[name] = value;
+    }
+    void checkAllParametersSet() {
+        if (unboundParams.length == 0)
+            return;
+        string list;
+        foreach(key, value; unboundParams) {
+            if (list.length > 0)
+                list ~= ", ";
+            list ~= key;
+        }
         enforceHelper!QueryParameterException(false, "Parameters " ~ list ~ " not set");
-	}
-	void applyParams(DataSetWriter ds) {
-		foreach(key, indexes; params) {
-			Variant value = values[key];
-			foreach(i; indexes)
-				ds.setVariant(i, value);
-		}
-	}
+    }
+    void applyParams(DataSetWriter ds) {
+        foreach(key, indexes; params) {
+            Variant value = values[key];
+            foreach(i; indexes)
+                ds.setVariant(i, value);
+        }
+    }
 }
 
 class ParsedQuery {
-	private string _hql;
-	private string _sql;
-	private int[][string]params; // contains 1-based indexes of ? ? ? placeholders in SQL for param by name
-	private int paramIndex = 1;
+    private string _hql;
+    private string _sql;
+    private int[][string]params; // contains 1-based indexes of ? ? ? placeholders in SQL for param by name
+    private int paramIndex = 1;
     private FromClause _from;
     private SelectClauseItem[] _select;
     private EntityInfo _entity;
-	private int _colCount = 0;
-	this(string hql) {
-		_hql = hql;
-	}
-	@property string hql() { return _hql; }
-	@property string sql() { return _sql; }
-	@property const(EntityInfo)entity() { return _entity; }
-	@property int colCount() { return _colCount; }
+    private int _colCount = 0;
+    this(string hql) {
+        _hql = hql;
+    }
+    @property string hql() { return _hql; }
+    @property string sql() { return _sql; }
+    @property const(EntityInfo)entity() { return _entity; }
+    @property int colCount() { return _colCount; }
     @property FromClause from() { return _from; }
     @property SelectClauseItem[] select() { return _select; }
     void setEntity(const EntityInfo entity) {
         _entity = cast(EntityInfo)entity;
-	}
+    }
     void setFromClause(FromClause from) {
         _from = from;
     }
     void setSelect(SelectClauseItem[] items) {
-        _select = items; 
+        _select = items;
     }
     void setColCount(int cnt) { _colCount = cnt; }
-	void addParam(string paramName) {
-		if ((paramName in params) is null) {
-			params[paramName] = [paramIndex++];
-		} else {
-			params[paramName] ~= [paramIndex++];
-		}
-	}
-	int[] getParam(string paramName) {
-		if ((paramName in params) is null) {
-			throw new HibernatedException("Parameter " ~ paramName ~ " not found in query " ~ _hql);
-		} else {
-			return params[paramName];
-		}
-	}
-	void appendSQL(string sql) {
-		_sql ~= sql;
-	}
-	void appendSpace() {
-		if (_sql.length > 0 && _sql[$ - 1] != ' ')
-			_sql ~= ' ';
-	}
-	ParameterValues createParams() {
-		return new ParameterValues(params);
-	}
+    void addParam(string paramName) {
+        if ((paramName in params) is null) {
+            params[paramName] = [paramIndex++];
+        } else {
+            params[paramName] ~= [paramIndex++];
+        }
+    }
+    int[] getParam(string paramName) {
+        if ((paramName in params) is null) {
+            throw new HibernatedException("Parameter " ~ paramName ~ " not found in query " ~ _hql);
+        } else {
+            return params[paramName];
+        }
+    }
+    void appendSQL(string sql) {
+        _sql ~= sql;
+    }
+    void appendSpace() {
+        if (_sql.length > 0 && _sql[$ - 1] != ' ')
+            _sql ~= ' ';
+    }
+    ParameterValues createParams() {
+        return new ParameterValues(params);
+    }
 }
 
 unittest {
-	ParsedQuery q = new ParsedQuery("FROM User where id = :param1 or id = :param2");
-	q.addParam("param1"); // 1
-	q.addParam("param2"); // 2
-	q.addParam("param1"); // 3
-	q.addParam("param1"); // 4
-	q.addParam("param3"); // 5
-	q.addParam("param2"); // 6
-	assert(q.getParam("param1") == [1,3,4]);
-	assert(q.getParam("param2") == [2,6]);
-	assert(q.getParam("param3") == [5]);
+    ParsedQuery q = new ParsedQuery("FROM User where id = :param1 or id = :param2");
+    q.addParam("param1"); // 1
+    q.addParam("param2"); // 2
+    q.addParam("param1"); // 3
+    q.addParam("param1"); // 4
+    q.addParam("param3"); // 5
+    q.addParam("param2"); // 6
+    assert(q.getParam("param1") == [1,3,4]);
+    assert(q.getParam("param2") == [2,6]);
+    assert(q.getParam("param3") == [5]);
 }
 
 unittest {
 
-	//trace("query unittest");
+    //trace("query unittest");
     import hibernated.tests;
 
     EntityMetaData schema = new SchemaInfoImpl!(User, Customer, AccountType, Address, Person, MoreInfo, EvenMoreInfo, Role);
-	QueryParser parser = new QueryParser(schema, "SELECT a FROM User AS a WHERE id = :Id AND name != :skipName OR name IS NULL  AND a.flags IS NOT NULL ORDER BY name, a.flags DESC");
-	assert(parser.parameterNames.length == 2);
-	//trace("param1=" ~ parser.parameterNames[0]);
-	//trace("param2=" ~ parser.parameterNames[1]);
-	assert(parser.parameterNames[0] == "Id");
-	assert(parser.parameterNames[1] == "skipName");
-	assert(parser.fromClause.length == 1);
-	assert(parser.fromClause.first.entity.name == "User");
+    QueryParser parser = new QueryParser(schema, "SELECT a FROM User AS a WHERE id = :Id AND name != :skipName OR name IS NULL  AND a.flags IS NOT NULL ORDER BY name, a.flags DESC");
+    assert(parser.parameterNames.length == 2);
+    //trace("param1=" ~ parser.parameterNames[0]);
+    //trace("param2=" ~ parser.parameterNames[1]);
+    assert(parser.parameterNames[0] == "Id");
+    assert(parser.parameterNames[1] == "skipName");
+    assert(parser.fromClause.length == 1);
+    assert(parser.fromClause.first.entity.name == "User");
     assert(parser.fromClause.first.entityAlias == "a");
-	assert(parser.selectClause.length == 1);
-	assert(parser.selectClause[0].prop is null);
-	assert(parser.selectClause[0].from.entity.name == "User");
-	assert(parser.orderByClause.length == 2);
-	assert(parser.orderByClause[0].prop.propertyName == "name");
-	assert(parser.orderByClause[0].from.entity.name == "User");
-	assert(parser.orderByClause[0].asc == true);
-	assert(parser.orderByClause[1].prop.propertyName == "flags");
-	assert(parser.orderByClause[1].from.entity.name == "User");
-	assert(parser.orderByClause[1].asc == false);
-	
-	parser = new QueryParser(schema, "SELECT a FROM User AS a WHERE ((id = :Id) OR (name LIKE 'a%' AND flags = (-5 + 7))) AND name != :skipName AND flags BETWEEN 2*2 AND 42/5 ORDER BY name, a.flags DESC");
-	assert(parser.whereClause !is null);
-	//trace(parser.whereClause.dump(0));
-	Dialect dialect = new MySQLDialect();
-	
-	assert(dialect.quoteSqlString("abc") == "'abc'");
-	assert(dialect.quoteSqlString("a'b'c") == "'a\\'b\\'c'");
-	assert(dialect.quoteSqlString("a\nc") == "'a\\nc'");
-	
-	parser = new QueryParser(schema, "FROM User AS u WHERE id = :Id and u.name like '%test%'");
-	ParsedQuery q = parser.makeSQL(dialect);
-	//trace(parser.whereClause.dump(0));
-	//trace(q.hql ~ "\n=>\n" ~ q.sql);
+    assert(parser.selectClause.length == 1);
+    assert(parser.selectClause[0].prop is null);
+    assert(parser.selectClause[0].from.entity.name == "User");
+    assert(parser.orderByClause.length == 2);
+    assert(parser.orderByClause[0].prop.propertyName == "name");
+    assert(parser.orderByClause[0].from.entity.name == "User");
+    assert(parser.orderByClause[0].asc == true);
+    assert(parser.orderByClause[1].prop.propertyName == "flags");
+    assert(parser.orderByClause[1].from.entity.name == "User");
+    assert(parser.orderByClause[1].asc == false);
 
-	//trace(q.hql);
-	//trace(q.sql);
+    parser = new QueryParser(schema, "SELECT a FROM User AS a WHERE ((id = :Id) OR (name LIKE 'a%' AND flags = (-5 + 7))) AND name != :skipName AND flags BETWEEN 2*2 AND 42/5 ORDER BY name, a.flags DESC");
+    assert(parser.whereClause !is null);
+    //trace(parser.whereClause.dump(0));
+    Dialect dialect = new MySQLDialect();
+
+    assert(dialect.quoteSqlString("abc") == "'abc'");
+    assert(dialect.quoteSqlString("a'b'c") == "'a\\'b\\'c'");
+    assert(dialect.quoteSqlString("a\nc") == "'a\\nc'");
+
+    parser = new QueryParser(schema, "FROM User AS u WHERE id = :Id and u.name like '%test%'");
+    ParsedQuery q = parser.makeSQL(dialect);
+    //trace(parser.whereClause.dump(0));
+    //trace(q.hql ~ "\n=>\n" ~ q.sql);
+
+    //trace(q.hql);
+    //trace(q.sql);
     parser = new QueryParser(schema, "SELECT a FROM Person AS a LEFT JOIN a.moreInfo as b LEFT JOIN b.evenMore c WHERE a.id = :Id AND b.flags > 0 AND c.flags > 0");
     assert(parser.fromClause.hasAlias("a"));
     assert(parser.fromClause.hasAlias("b"));
@@ -1834,7 +1834,7 @@ unittest {
 //    trace(q.hql);
 //    trace(q.sql);
     assert(q.sql == "SELECT _t1.id, _t1.name FROM role AS _t1 LEFT JOIN role_users AS _t1_t2 ON _t1.id=_t1_t2.role_fk LEFT JOIN users AS _t2 ON _t1_t2.user_fk=_t2.id WHERE _t2.id = 1");
-    
+
     parser = new QueryParser(schema, "FROM User WHERE customer.id = 1");
     q = parser.makeSQL(dialect);
 //    trace(q.hql);
@@ -1852,5 +1852,5 @@ unittest {
     //trace(q.hql);
     //trace(q.sql);
     assert(q.sql == "SELECT _t2.id, _t2.name, _t2.flags, _t2.comment, _t2.customer_fk FROM customers AS _t1 INNER JOIN users AS _t2 ON _t1.id=_t2.customer_fk WHERE _t1.id = 1");
-    
+
 }

--- a/source/hibernated/query.d
+++ b/source/hibernated/query.d
@@ -1721,6 +1721,7 @@ unittest {
     assert(q.getParam("param3") == [5]);
 }
 
+/+
 unittest {
 
     //trace("query unittest");
@@ -1854,3 +1855,4 @@ unittest {
     assert(q.sql == "SELECT _t2.id, _t2.name, _t2.flags, _t2.comment, _t2.customer_fk FROM customers AS _t1 INNER JOIN users AS _t2 ON _t1.id=_t2.customer_fk WHERE _t1.id = 1");
 
 }
++/

--- a/source/hibernated/tests.d
+++ b/source/hibernated/tests.d
@@ -1,13 +1,13 @@
 /**
- * HibernateD - Object-Relation Mapping for D programming language, with interface similar to Hibernate. 
- * 
+ * HibernateD - Object-Relation Mapping for D programming language, with interface similar to Hibernate.
+ *
  * Hibernate documentation can be found here:
  * $(LINK http://hibernate.org/docs)$(BR)
- * 
+ *
  * Source file hibernated/tests.d.
  *
  * This module contains unit tests for functional testing on real DB.
- * 
+ *
  * Copyright: Copyright 2013
  * License:   $(LINK www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Author:   Vadim Lopatin
@@ -26,17 +26,18 @@ private import ddbc.core : Connection, DataSource, Statement;
 
 private import hibernated.core;
 
+/+
 version(unittest) {
 
     //@Entity
     @Table("users") // to override table name - "users" instead of default "user"
     class User {
-        
+
         //@Generated
         long id;
-        
+
         string name;
-        
+
         // property column
         private long _flags;
         @Null // override NotNull which is inferred from long type
@@ -50,21 +51,21 @@ version(unittest) {
         @Column(null, 1024) // override default length, autogenerate column name)
         string getComment() { return comment; }
         void setComment(string v) { comment = v; }
-        
+
         //@ManyToOne -- not mandatory, will be deduced
         //@JoinColumn("customer_fk")
         Customer customer;
-        
+
         @ManyToMany
         LazyCollection!Role roles;
-        
+
         override string toString() {
             return "id=" ~ to!string(id) ~ ", name=" ~ name ~ ", flags=" ~ to!string(flags) ~ ", comment=" ~ comment ~ ", customerId=" ~ (customer is null ? "NULL" : customer.toString());
         }
-        
+
     }
-    
-    
+
+
     //@Entity
     @Table("customers") // to override table name - "customers" instead of default "customer"
     class Customer {
@@ -75,19 +76,19 @@ version(unittest) {
 
         // deduced as @Embedded automatically
         Address address;
-        
+
         //@ManyToOne -- not mandatory, will be deduced
         //@JoinColumn("account_type_fk")
         Lazy!AccountType accountType;
-        
+
         //        @OneToMany("customer")
         //        LazyCollection!User users;
-        
+
         //@OneToMany("customer") -- not mandatory, will be deduced
         private User[] _users;
         @property User[] users() { return _users; }
         @property void users(User[] value) { _users = value; }
-        
+
         this() {
             address = new Address();
         }
@@ -97,7 +98,7 @@ version(unittest) {
     }
 
     static assert(isEmbeddedObjectMember!(Customer, "address"));
-    
+
     @Embeddable
     class Address {
         hibernated.type.String zip;
@@ -110,53 +111,53 @@ version(unittest) {
             return " zip=" ~ zip ~ ", city=" ~ city ~ ", streetAddress=" ~ streetAddress;
         }
     }
-    
+
     @Entity // need to have at least one annotation to import automatically from module
     class AccountType {
         //@Generated
         int id;
         string name;
     }
-    
-    //@Entity 
+
+    //@Entity
     class Role {
         //@Generated
         int id;
         string name;
-        @ManyToMany 
+        @ManyToMany
         LazyCollection!User users;
     }
-    
+
     //@Entity
     //@Table("t1")
     class T1 {
-        //@Id 
+        //@Id
         //@Generated
         int id;
-        
-        //@NotNull 
+
+        //@NotNull
         @UniqueKey
         string name;
-        
+
         // property column
         private long _flags;
         // @Column -- not mandatory, will be deduced
         @property long flags() { return _flags; }
         @property void flags(long v) { _flags = v; }
-        
+
         // getter/setter property
         private string comment;
         // @Column -- not mandatory, will be deduced
         @Null
         string getComment() { return comment; }
         void setComment(string v) { comment = v; }
-        
-        
+
+
         override string toString() {
             return "id=" ~ to!string(id) ~ ", name=" ~ name ~ ", flags=" ~ to!string(flags) ~ ", comment=" ~ comment;
         }
     }
-    
+
     @Entity
     static class GeneratorTest {
         //@Generator("std.uuid.randomUUID().toString()")
@@ -164,7 +165,7 @@ version(unittest) {
         string id;
         string name;
     }
-    
+
     @Entity
     static class TypeTest {
         //@Generated
@@ -198,7 +199,7 @@ version(unittest) {
         byte[] byte_array_field;
         ubyte[] ubyte_array_field;
     }
-    
+
     import ddbc.drivers.mysqlddbc;
     import ddbc.drivers.pgsqlddbc;
     import ddbc.drivers.sqliteddbc;
@@ -207,8 +208,8 @@ version(unittest) {
     import hibernated.dialects.sqlitedialect;
     import hibernated.dialects.pgsqldialect;
 
-    
-    string[] UNIT_TEST_DROP_TABLES_SCRIPT = 
+
+    string[] UNIT_TEST_DROP_TABLES_SCRIPT =
         [
          "DROP TABLE IF EXISTS role_users",
          "DROP TABLE IF EXISTS account_type",
@@ -220,7 +221,7 @@ version(unittest) {
          "DROP TABLE IF EXISTS role",
          "DROP TABLE IF EXISTS generator_test",
          ];
-    string[] UNIT_TEST_CREATE_TABLES_SCRIPT = 
+    string[] UNIT_TEST_CREATE_TABLES_SCRIPT =
         [
          "CREATE TABLE IF NOT EXISTS role (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, name VARCHAR(255) NOT NULL)",
          "CREATE TABLE IF NOT EXISTS account_type (id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, name VARCHAR(255) NOT NULL)",
@@ -232,7 +233,7 @@ version(unittest) {
          "CREATE TABLE IF NOT EXISTS role_users (role_fk int not null, user_fk int not null, primary key (role_fk, user_fk), unique index(user_fk, role_fk))",
          "CREATE TABLE IF NOT EXISTS generator_test (id varchar(64) not null primary key, name varchar(255) not null)",
          ];
-    string[] UNIT_TEST_FILL_TABLES_SCRIPT = 
+    string[] UNIT_TEST_FILL_TABLES_SCRIPT =
         [
          "INSERT INTO role (name) VALUES ('admin')",
          "INSERT INTO role (name) VALUES ('viewer')",
@@ -322,10 +323,10 @@ version(unittest) {
 
 
 unittest {
-    
+
     // Checking generated metadata
     EntityMetaData schema = new SchemaInfoImpl!(User, Customer, AccountType, T1, TypeTest, Address, Role);
-    
+
     //writeln("metadata test 1");
     assert(schema["TypeTest"].length==29);
     assert(schema.getEntityCount() == 7);
@@ -426,15 +427,15 @@ unittest {
     //    schema.setPropertyValue(e2user, "customer", Variant(c42));
     //    assert(e2user.customer.id == 42);
     //    //assert(schema.getPropertyValue(e2user, "customer") == 42);
-    
+
     Object e1 = schema.findEntity("User").createEntity();
     assert(e1 !is null);
     User e1user = cast(User)e1;
     assert(e1user !is null);
     e1user.id = 25;
-    
-    
-    
+
+
+
 }
 
 unittest {
@@ -443,7 +444,7 @@ unittest {
 
 
         //writeln("metadata test 2");
-        
+
         // Checking generated metadata
         EntityMetaData schema = new SchemaInfoImpl!(User, Customer, AccountType, T1, TypeTest, Address, Role, GeneratorTest, Person, MoreInfo, EvenMoreInfo);
         Dialect dialect = getUnitTestDialect();
@@ -495,7 +496,7 @@ unittest {
         {
             Session sess = factory.openSession();
             scope(exit) sess.close();
-            
+
             User u1 = sess.load!User(1);
             //writeln("Loaded value: " ~ u1.toString);
             assert(u1.id == 1);
@@ -505,29 +506,29 @@ unittest {
             assert(u1.customer.accountType().name == "Type1");
             Role[] u1roles = u1.roles;
             assert(u1roles.length == 2);
-            
+
             User u2 = sess.load!User(2);
             assert(u2.name == "user 2");
             assert(u2.flags == 22); // NULL is loaded as 0 if property cannot hold nulls
-            
+
             User u3 = sess.get!User(3);
             assert(u3.name == "user 3");
             assert(u3.flags == 0); // NULL is loaded as 0 if property cannot hold nulls
             assert(u3.getComment() !is null);
             assert(u3.customer.name == "customer 2");
             assert(u3.customer.accountType() is null);
-            
+
             User u4 = new User();
             sess.load(u4, 4);
             assert(u4.name == "user 4");
             assert(u4.getComment() is null);
-            
+
             User u5 = new User();
             u5.id = 5;
             sess.refresh(u5);
             assert(u5.name == "test user 5");
             //assert(u5.customer !is null);
-            
+
             u5 = sess.load!User(5);
             assert(u5.name == "test user 5");
             assert(u5.customer !is null);
@@ -535,12 +536,12 @@ unittest {
             assert(u5.customer.name == "customer 3");
             assert(u5.customer.accountType() !is null);
             assert(u5.customer.accountType().name == "Type2");
-            
+
             User u6 = sess.load!User(6);
             assert(u6.name == "test user 6");
             assert(u6.customer is null);
-            
-            // 
+
+            //
             //writeln("loading customer 3");
             // testing @Embedded property
             Customer c3 = sess.load!Customer(3);
@@ -548,13 +549,13 @@ unittest {
             assert(c3.address.streetAddress == "Baker Street, 24");
             c3.address.streetAddress = "Baker Street, 24/2";
             c3.address.zip = "55555";
-            
+
             User[] c3users = c3.users;
             //writeln("        ***      customer has " ~ to!string(c3users.length) ~ " users");
             assert(c3users.length == 2);
             assert(c3users[0].customer == c3);
             assert(c3users[1].customer == c3);
-            
+
             //writeln("updating customer 3");
             sess.update(c3);
             Customer c3_reloaded = sess.load!Customer(3);
@@ -566,37 +567,37 @@ unittest {
             Session sess = factory.openSession();
             scope(exit) sess.close();
 
-            
+
             // check Session.save() when id is filled
             Customer c4 = new Customer();
             c4.id = 4;
             c4.name = "Customer_4";
             sess.save(c4);
-            
+
             Customer c4_check = sess.load!Customer(4);
             assert(c4.id == c4_check.id);
             assert(c4.name == c4_check.name);
-            
+
             sess.remove(c4);
-            
+
             c4 = sess.get!Customer(4);
             assert (c4 is null);
-            
+
             Customer c5 = new Customer();
             c5.name = "Customer_5";
             sess.save(c5);
-            
+
             // Testing generator function (uuid)
             GeneratorTest g1 = new GeneratorTest();
             g1.name = "row 1";
             assert(g1.id is null);
             sess.save(g1);
             assert(g1.id !is null);
-            
-            
+
+
             assertThrown!MappingException(sess.createQuery("SELECT id, name, blabla FROM User ORDER BY name"));
             assertThrown!QuerySyntaxException(sess.createQuery("SELECT id: name FROM User ORDER BY name"));
-            
+
             // test multiple row query
             Query q = sess.createQuery("FROM User ORDER BY name");
             User[] list = q.list!User();
@@ -615,7 +616,7 @@ unittest {
             //      }
             assertThrown!HibernatedException(q.uniqueResult!User());
             assertThrown!HibernatedException(q.uniqueRow());
-            
+
         }
         {
             Session sess = factory.openSession();
@@ -637,14 +638,14 @@ unittest {
             Variant[] row = q.uniqueRow();
             assert(row[0] == 6L);
             assert(row[1] == "test user 6");
-            
+
             // test empty SELECT result
             q.setParameter("Id", Variant(7));
             row = q.uniqueRow();
             assert(row is null);
             uu = q.uniqueResult!User();
             assert(uu is null);
-            
+
             q = sess.createQuery("SELECT c.name, c.address.zip FROM Customer AS c WHERE id = :Id").setParameter("Id", Variant(1));
             row = q.uniqueRow();
             assert(row !is null);
@@ -717,65 +718,65 @@ unittest {
 
 version (unittest) {
     // for testing of Embeddable
-    @Embeddable 
+    @Embeddable
     class EMName {
         string firstName;
         string lastName;
     }
-    
-    //@Entity 
+
+    //@Entity
     class EMUser {
         //@Id @Generated
         //@Column
         int id;
-        
+
         // deduced as @Embedded automatically
         EMName userName;
     }
-    
+
     // for testing of Embeddable
     //@Entity
     class Person {
         //@Id
         int id;
-        
-        // @Column @NotNull        
+
+        // @Column @NotNull
         string firstName;
-        // @Column @NotNull        
+        // @Column @NotNull
         string lastName;
-        
+
         @NotNull
         @OneToOne
         @JoinColumn("more_info_fk")
         MoreInfo moreInfo;
     }
-    
-    
+
+
     //@Entity
     @Table("person_info")
     class MoreInfo {
         //@Id @Generated
         int id;
-        // @Column 
+        // @Column
         long flags;
         @OneToOne("moreInfo")
         Person person;
         @OneToOne("personInfo")
         EvenMoreInfo evenMore;
     }
-    
+
     //@Entity
     @Table("person_info2")
     class EvenMoreInfo {
         //@Id @Generated
         int id;
-        //@Column 
+        //@Column
         long flags;
         @OneToOne
         @JoinColumn("person_info_fk")
         MoreInfo personInfo;
     }
-    
+
 }
 
 
@@ -786,10 +787,10 @@ unittest {
     static assert(getPropertyEmbeddedEntityName!(EMUser, "userName") == "EMName");
     static assert(getPropertyEmbeddedClassName!(EMUser, "userName") == "hibernated.tests.EMName");
     //pragma(msg, getEmbeddedPropertyDef!(EMUser, "userName")());
-    
+
     // Checking generated metadata
     EntityMetaData schema = new SchemaInfoImpl!(EMName, EMUser);
-    
+
     static assert(hasMemberAnnotation!(Person, "moreInfo", OneToOne));
     static assert(getPropertyReferencedEntityName!(Person, "moreInfo") == "MoreInfo");
     static assert(getPropertyReferencedClassName!(Person, "moreInfo") == "hibernated.tests.MoreInfo");
@@ -800,24 +801,24 @@ unittest {
     static assert(getJoinColumnName!(Person, "moreInfo") == "more_info_fk");
     static assert(getOneToOneReferencedPropertyName!(MoreInfo, "person") == "moreInfo");
     static assert(getOneToOneReferencedPropertyName!(Person, "moreInfo") is null);
-    
+
     //pragma(msg, "done getOneToOneReferencedPropertyName");
-    
+
     // Checking generated metadata
     //EntityMetaData schema = new SchemaInfoImpl!(Person, MoreInfo);
     //  foreach(e; schema["Person"]) {
     //      writeln("property: " ~ e.propertyName);
     //  }
-    schema = new SchemaInfoImpl!(hibernated.tests); //Person, MoreInfo, EvenMoreInfo, 
-    
+    schema = new SchemaInfoImpl!(hibernated.tests); //Person, MoreInfo, EvenMoreInfo,
+
     {
-        
+
         int[Variant] map0;
         map0[Variant(1)] = 3;
         assert(map0[Variant(1)] == 3);
         map0[Variant(1)]++;
         assert(map0[Variant(1)] == 4);
-        
+
         //writeln("map test");
         PropertyLoadMap map = new PropertyLoadMap();
         Person ppp1 = new Person();
@@ -853,13 +854,13 @@ unittest {
         assert(m[Variant(1)].length == 1);
         assert(m[Variant(2)].length == 2);
     }
-    
+
     if (DB_TESTS_ENABLED) {
         //recreateTestSchema();
-        
+
         //writeln("metadata test 2");
         import hibernated.dialects.mysqldialect;
-        
+
         // Checking generated metadata
         Dialect dialect = getUnitTestDialect();
         DataSource ds = getUnitTestDataSource();
@@ -873,7 +874,7 @@ unittest {
 
             auto p1 = sess.get!Person(1);
             assert(p1.firstName == "Andrei");
-            
+
 
             // all non-null oneToOne relations
             auto q = sess.createQuery("FROM Person WHERE id=:Id").setParameter("Id", Variant(1));
@@ -900,8 +901,7 @@ unittest {
             assert(p2.moreInfo.evenMore is null);
 
         }
-        
+
     }
 }
-
-
++/


### PR DESCRIPTION
This is a draft PR which is not yet complete, but due to the amount of work remaining, I thought it would be a good idea to share some of the early progress.

There is a new module added as `hibernated.hql`, and this module contains only the logic to parse HQL queries, which will serve as a the basis to support a much larger set of features than just `FROM ... WHERE ...` HQL queries. Furthermore, when properly integrated, PEG parsers can give users far more precise feedback in terms of syntax errors.

This work relates to the desire to add more HQL features, such as bulk insert/update/delete mentioned in Issue #92.