### PR TITLE
Bug: DelayedLoadRelations uses inconsistent quoting for string-literals.

### DIFF
--- a/hdtest/source/generaltest.d
+++ b/hdtest/source/generaltest.d
@@ -263,8 +263,14 @@ class GeneralTest : HibernateTest {
       a1.name = "Bucky O'Hare";
       int id = sess.save(a1).get!int;
 
-      auto query = sess.createQuery("FROM Asset WHERE name=:Name").setParameter("Name", "Bucky O'Hare").list!Asset;
-      assert(query.length == 1);
+      auto result = sess.createQuery("FROM Asset WHERE name=:Name")
+              .setParameter("Name", "Bucky O'Hare")
+              .list!Asset();
+      assert(result.length == 1);
+
+      result = sess.createQuery("FROM Asset WHERE name='Bucky O''Hare'")
+              .list!Asset();
+      assert(result.length == 1);
   }
 }
 

--- a/hdtest/source/generaltest.d
+++ b/hdtest/source/generaltest.d
@@ -263,8 +263,8 @@ class GeneralTest : HibernateTest {
       a1.name = "Bucky O'Hare";
       int id = sess.save(a1).get!int;
 
-      auto query = sess.createQuery("FROM Asset WHERE name=:Name").setParameter("Name", "Bucky O'Hare");
-      writeln("FLOOB: query results", query.listRows());
+      auto query = sess.createQuery("FROM Asset WHERE name=:Name").setParameter("Name", "Bucky O'Hare").list!Asset;
+      assert(query.length == 1);
   }
 }
 

--- a/hdtest/source/generaltest.d
+++ b/hdtest/source/generaltest.d
@@ -253,5 +253,18 @@ class GeneralTest : HibernateTest {
       assert(allUsers.length == 2); // Should only be 2 users now
     }
   }
+
+  @Test("quote escape test")
+  void quoteEscapeTest() {
+      Session sess = sessionFactory.openSession();
+      scope(exit) sess.close();
+
+      auto a1 = new Asset();
+      a1.name = "Bucky O'Hare";
+      int id = sess.save(a1).get!int;
+
+      auto query = sess.createQuery("FROM Asset WHERE name=:Name").setParameter("Name", "Bucky O'Hare");
+      writeln("FLOOB: query results", query.listRows());
+  }
 }
 

--- a/source/hibernated/annotations.d
+++ b/source/hibernated/annotations.d
@@ -266,7 +266,6 @@ struct ManyToMany {
     immutable string joinColumn2;
 }
 
-
 unittest {
     @Entity
     @Table("user")

--- a/source/hibernated/dialect.d
+++ b/source/hibernated/dialect.d
@@ -109,7 +109,8 @@ abstract class Dialect {
 		string res = "'";
 		foreach(ch; s) {
 			switch(ch) {
-				case '\'': res ~= "\\\'"; break;
+                // All dialects support the SQL-standard way of escaping a (') character via ('').
+				case '\'': res ~= "''"; break;
 				case '\"': res ~= "\\\""; break;
 				case '\\': res ~= "\\\\"; break;
 				case '\0': res ~= "\\n"; break;

--- a/source/hibernated/query.d
+++ b/source/hibernated/query.d
@@ -1443,6 +1443,12 @@ class Token {
 	
 }
 
+/**
+ * Converts an HQL string into a series of tokens to be later converted to SQL.
+ *
+ * HQL follows the Jakarta Persistence specification, which requires escaping (') characters via ('').
+ * See: https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#literals
+ */
 Token[] tokenize(string s) {
 	Token[] res;
 	int startpos = 0;
@@ -1521,11 +1527,10 @@ Token[] tokenize(string s) {
 			// string constant
 			i++;
 			for(int j=i; j<len; j++) {
-				// In SQL, (') characters are quoted as ('').
+				// In HQL, (') characters are quoted as (''), so undo that escaping.
 				if (s[j] == '\'' && j+1 < len && s[j+1] == '\'') {
 					text ~= s[j];
 					j++;
-					text ~= s[j];
 				}
 				else if (s[j] != '\'') {
 					text ~= s[j];


### PR DESCRIPTION
If using HQL on an Entity that is implicitly joined to other Entities via @OneToOne, @OneToMany, @ManyToOne, or @ManyToMany, and an ID value has a single-quote (') in it, the HQL-escaping ('') is not unescaped, and it gets escaped into the dialect, resulting in (\\'\\'), and a query that has a syntax error.

Example debug statements:
```
[trace] session.d:1207:delayedLoadRelations unknownKeys = [Bucky O'Hare] [trace] session.d:1208:delayedLoadRelations createCommaSeparatedKeyList(unknownKeys) = 'Bucky O''Hare'
                                                               extra quote is being added here ^
[trace] session.d:1290:listObjects SQL: SELECT _t1.contract_code, ... FROM finance_contract_refs AS _t1 WHERE _t1.contract_code IN ( 'Bucky O\\'\\'Hare') 
```

The error is as follows when using a PostgreSQL dialect.
```
Fatal error executing prepared statement SELECT _t1.contract_code, ...  FROM finance_contract_refs AS _t1 WHERE _t1.contract_code IN ( 'Bucky O\\'\\'Hare'): ERROR:  syntax error at or near "\\"\nLINE 1: ...HERE _t1.contract_code IN ( 'Bucky O\\'\\'Hare...\n     
```

The fix is to modify the HQL Parser to unescape ('') as ('), and then let specific dialects re-escape the ('). PostgreSQL, by default, does not support C-style escape characters unless quoted as E'hello\nthere\n' (note the leading (E)). However, all dialects support the SQL standard ('') syntax.